### PR TITLE
feat(webapp): Scoring for fastest answer and display of time taken

### DIFF
--- a/QuizMaster.Application/ParticipantMessage.cs
+++ b/QuizMaster.Application/ParticipantMessage.cs
@@ -5,5 +5,6 @@ namespace QuizMaster.Application
     {
         public Guid ParticipantId { get; set; }
         public string Answer { get; set; }
+        public float AnswerTime { get; set; }
     }
 }

--- a/QuizMaster.Application/ParticipantMessage.cs
+++ b/QuizMaster.Application/ParticipantMessage.cs
@@ -5,6 +5,6 @@ namespace QuizMaster.Application
     {
         public Guid ParticipantId { get; set; }
         public string Answer { get; set; }
-        public float AnswerTime { get; set; }
+        public float AnswerTimeLeftAsAPercentage { get; set; }
     }
 }

--- a/quizmaster-client-app/src/components/Common/ParticipantMessage.ts
+++ b/quizmaster-client-app/src/components/Common/ParticipantMessage.ts
@@ -1,7 +1,7 @@
 interface ParticipantMessage {
   participantId: string;
   answer: string;
-  answerTime: number;
+  answerTimeLeftAsAPercentage: number;
 }
 
 export default ParticipantMessage;

--- a/quizmaster-client-app/src/components/Common/ParticipantMessage.ts
+++ b/quizmaster-client-app/src/components/Common/ParticipantMessage.ts
@@ -1,6 +1,7 @@
 interface ParticipantMessage {
   participantId: string;
   answer: string;
+  answerTime: number;
 }
 
 export default ParticipantMessage;

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
@@ -118,6 +118,7 @@ interface HeadCell {
 const headCells: HeadCell[] = [
   { id: "answer", numeric: false, disablePadding: false, label: "Answer" },
   { id: "name", numeric: false, disablePadding: false, label: "Name" },
+  { id: "answerTime", numeric: true, disablePadding: false, label: "Time Remaining" },
 ];
 
 interface EnhancedTableProps {
@@ -256,7 +257,8 @@ export default function QuestionMarker(props: {
   }, [props.answer, props.rows]);
 
   const onAcceptAnswers = () => {
-    props.onAcceptAnswers(selected);
+    const correctAnswers = props.rows.filter((x) => selected.includes(x.id))
+    props.onAcceptAnswers(correctAnswers);
   };
 
   const handleRequestSort = (
@@ -348,6 +350,7 @@ export default function QuestionMarker(props: {
                     </TableCell>
                     <TableCell align="center">{row.answer}</TableCell>
                     <TableCell align="center">{row.name}</TableCell>
+                    <TableCell align="center">{row.answerTime}</TableCell>
                   </TableRow>
                 );
               },

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
@@ -118,7 +118,7 @@ interface HeadCell {
 const headCells: HeadCell[] = [
   { id: "answer", numeric: false, disablePadding: false, label: "Answer" },
   { id: "name", numeric: false, disablePadding: false, label: "Name" },
-  { id: "answerTimeLeftAsAPercentage", numeric: true, disablePadding: false, label: "Time Remaining" },
+  { id: "answerTimeLeftAsAPercentage", numeric: true, disablePadding: false, label: "Time Remaining (%)" },
 ];
 
 interface EnhancedTableProps {

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
@@ -118,7 +118,7 @@ interface HeadCell {
 const headCells: HeadCell[] = [
   { id: "answer", numeric: false, disablePadding: false, label: "Answer" },
   { id: "name", numeric: false, disablePadding: false, label: "Name" },
-  { id: "answerTime", numeric: true, disablePadding: false, label: "Time Remaining" },
+  { id: "answerTimeLeftAsAPercentage", numeric: true, disablePadding: false, label: "Time Remaining" },
 ];
 
 interface EnhancedTableProps {
@@ -350,7 +350,7 @@ export default function QuestionMarker(props: {
                     </TableCell>
                     <TableCell align="center">{row.answer}</TableCell>
                     <TableCell align="center">{row.name}</TableCell>
-                    <TableCell align="center">{row.answerTime}</TableCell>
+                    <TableCell align="center">{row.answerTimeLeftAsAPercentage}</TableCell>
                   </TableRow>
                 );
               },

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionResponse.ts
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionResponse.ts
@@ -2,7 +2,7 @@ interface QuestionResponse {
   answer: string;
   name: string;
   id: string;
-  answerTime: number;
+  answerTimeLeftAsAPercentage: number;
 }
 
 export default QuestionResponse;

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionResponse.ts
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionResponse.ts
@@ -2,6 +2,7 @@ interface QuestionResponse {
   answer: string;
   name: string;
   id: string;
+  answerTime: number;
 }
 
 export default QuestionResponse;

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -168,7 +168,7 @@ export default function QuizHoster() {
  
     function progress() {
       if(!answersSubmitted){
-        setTimeLeftAsAPercentage((oldCompleted) => {
+        setTimeLeftAsAPercentage(() => {
           let increment = 100*(Date.now() - questionStartTime)/(totalTimeInSeconds*1000)
           return Math.max(100 - increment, 0);
         });

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -16,6 +16,8 @@ import QuestionMarker from "./QuestionMarker";
 import Data from "./QuestionResponse";
 import ParticipantMessage from "../Common/ParticipantMessage";
 import QuizStandings from "./QuizStandings";
+import QuestionResponse from "./QuestionResponse";
+import ContestantScore from "./ContestantScore";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -43,6 +45,9 @@ export default function QuizHoster() {
   const [quizIsComplete, setQuizIsComplete] = useState(false);
   const [answers, setAnswers] = useState<Data[]>([]);
   const [quizQuestions, setQuizQuestions] = useState<QuizQuestion[]>([]);
+  const [totalTimeInSeconds, setTotalTimeInSeconds]  = useState(0);
+  const [questionStartTime, setQuestionStartTime]  = useState(0);
+  const [answersSubmitted, setAnswersSubmitted] = useState(false);
 
   const [currentQuestionNumber, setCurrentQuestionNumber] = useState(0);
 
@@ -68,6 +73,9 @@ export default function QuizHoster() {
       .then(() => {
         setCurrentQuestionNumber((currentNumber) => currentNumber + 1);
       });
+    setTotalTimeInSeconds(120);
+    setQuestionStartTime(Date.now());
+    setAnswersSubmitted(false);
     setTimeLeftAsAPercentage(100);
   };
 
@@ -109,18 +117,52 @@ export default function QuizHoster() {
     }
   };
 
+  function getContestantScoreForRound(scores: ContestantScore[],contestantId: String): number {
+    let score = 0;
+    scores.forEach(contestant => {
+      if(contestantId == contestant.ContestantId){
+        score = contestant.Score;
+      }
+    })
+    return score;
+  }
+  
   const onAcceptAnswers = (
-    contestantsWithCorrectAnswerToCurrentQuestion: string[],
+    correctResponses: QuestionResponse[],
   ) => {
+
+    setAnswersSubmitted(true);
+
+    //Loop through responses to determine fastest answer
+    let fastestContestant:String = "";
+    let fastestContestantTime:number = 0;
+    correctResponses.forEach(response => {
+      if(response.answerTime > fastestContestantTime){
+        fastestContestantTime = response.answerTime;
+        fastestContestant = response.id;
+      }     
+    });
+    
+    //Loop through responses to build scores
+    let roundScores:ContestantScore[] = [];
+    correctResponses.forEach(response => {
+      let score = 1;
+      if(response.id == fastestContestant){
+        score = 2;
+      }     
+      const contestantScore: ContestantScore = {
+        ContestantId: response.id,
+        ContestantName: response.name,
+        Score: score
+      }
+      roundScores.push(contestantScore);
+    });
+    
     setContestants((contestants) =>
       contestants.map((contestant) => {
         return {
           ...contestant,
-          score: contestantsWithCorrectAnswerToCurrentQuestion.includes(
-            contestant.id,
-          )
-            ? contestant.score + 1
-            : contestant.score,
+          score: contestant.score + getContestantScoreForRound(roundScores,contestant.id)
         };
       }),
     );
@@ -128,12 +170,19 @@ export default function QuizHoster() {
   };
 
   useEffect(() => {
+    const interval = 100;
+ 
     function progress() {
-      setTimeLeftAsAPercentage((oldCompleted) => {
-        return Math.max(oldCompleted - 10, 0);
-      });
+      if(!answersSubmitted){
+        setTimeLeftAsAPercentage((oldCompleted) => {
+          let increment = 100*(Date.now() - questionStartTime)/(totalTimeInSeconds*1000)
+          return Math.max(100 - increment, 0);
+          //return Math.max(oldCompleted - 1, 0);
+        });
+      }
     }
-    const timer = setInterval(progress, 1000);
+    
+    const timer = setInterval(progress, interval);
 
     return () => {
       clearInterval(timer);
@@ -206,6 +255,7 @@ export default function QuizHoster() {
               name: contestantsList.filter(
                 (x) => x.id === message.participantId,
               )[0].name,
+              answerTime: message.answerTime,
             },
           ]);
         });
@@ -232,6 +282,7 @@ export default function QuizHoster() {
               <QuizQuestionDisplay
                 quizQuestion={getCurrentQuizQuestion()}
                 timeLeftAsAPercentage={timeLeftAsAPercentage}
+                totalTimeInSeconds={totalTimeInSeconds}
               />
             ) : (
               <></>

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -118,13 +118,7 @@ export default function QuizHoster() {
   };
 
   function getContestantScoreForRound(scores: ContestantScore[],contestantId: String): number {
-    let score = 0;
-    scores.forEach(contestant => {
-      if(contestantId == contestant.ContestantId){
-        score = contestant.Score;
-      }
-    })
-    return score;
+    return scores.find(x => x.ContestantId == contestantId)?.Score ?? 0;
   }
   
   const onAcceptAnswers = (
@@ -135,10 +129,10 @@ export default function QuizHoster() {
 
     //Loop through responses to determine fastest answer
     let fastestContestant:String = "";
-    let fastestContestantTime:number = 0;
+    let fastestContestantTimeLeft:number = 0;
     correctResponses.forEach(response => {
-      if(response.answerTime > fastestContestantTime){
-        fastestContestantTime = response.answerTime;
+      if(response.answerTimeLeftAsAPercentage > fastestContestantTimeLeft){
+        fastestContestantTimeLeft = response.answerTimeLeftAsAPercentage;
         fastestContestant = response.id;
       }     
     });
@@ -177,7 +171,6 @@ export default function QuizHoster() {
         setTimeLeftAsAPercentage((oldCompleted) => {
           let increment = 100*(Date.now() - questionStartTime)/(totalTimeInSeconds*1000)
           return Math.max(100 - increment, 0);
-          //return Math.max(oldCompleted - 1, 0);
         });
       }
     }
@@ -255,7 +248,7 @@ export default function QuizHoster() {
               name: contestantsList.filter(
                 (x) => x.id === message.participantId,
               )[0].name,
-              answerTime: message.answerTime,
+              answerTimeLeftAsAPercentage: message.answerTimeLeftAsAPercentage,
             },
           ]);
         });

--- a/quizmaster-client-app/src/components/QuizHosting/QuizQuestionDisplay.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizQuestionDisplay.tsx
@@ -33,6 +33,7 @@ export default function QuizQuestionDisplay(props: any) {
           variant="determinate"
           value={props.timeLeftAsAPercentage}
         />
+        <Typography component="h1" variant="h5">{((props.timeLeftAsAPercentage/100.0) * props.totalTimeInSeconds).toFixed(2)} seconds remaining</Typography>
       </div>
     </div>
   );

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -92,7 +92,7 @@ export default function QuestionResponder() {
  
     function progress() {
       if(!answerSubmitted){
-        setTimeLeftAsAPercentage((oldCompleted) => {
+        setTimeLeftAsAPercentage(() => {
           let increment = 100*(Date.now() - startTime)/(totalTimeInSeconds*1000)
           return Math.max(100 - increment, 0);
         });

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -63,7 +63,7 @@ export default function QuestionResponder() {
     const message: ParticipantMessage = {
       participantId: participantId,
       answer: answer,
-      answerTime: timeLeftAsAPercentage
+      answerTimeLeftAsAPercentage: timeLeftAsAPercentage
     };
     setSubmitText("Submitted. Please Wait.");
     axios.post(`/api/quizzes/${quizId}/command/participantmessage`, message);
@@ -95,7 +95,6 @@ export default function QuestionResponder() {
         setTimeLeftAsAPercentage((oldCompleted) => {
           let increment = 100*(Date.now() - startTime)/(totalTimeInSeconds*1000)
           return Math.max(100 - increment, 0);
-          //return Math.max(oldCompleted - 1, 0);
         });
       }
     }

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -51,16 +51,20 @@ export default function QuestionResponder() {
   const [submitText, setSubmitText] = useState("Submit");
   const { quizId } = useParams();
   const [participantId, setParticipantId] = useState("");
+  const [startTime, setStartTime] = useState(0);
+  const [totalTimeInSeconds, setTotalTimeInSeconds] = useState(0);
+  const [answerSubmitted, setAnswerSubmitted] = useState(false);
 
   const onAnswerChange = (e: ChangeEvent<HTMLInputElement>) =>
     setAnswer(e.currentTarget.value);
 
   const onAnswerSubmit = () => {
+    setAnswerSubmitted(true);
     const message: ParticipantMessage = {
       participantId: participantId,
       answer: answer,
+      answerTime: timeLeftAsAPercentage
     };
-
     setSubmitText("Submitted. Please Wait.");
     axios.post(`/api/quizzes/${quizId}/command/participantmessage`, message);
 
@@ -76,18 +80,26 @@ export default function QuestionResponder() {
     }
   }
 
+
   useEffect(() => {
     const participantID = localStorage.getItem("participantId") || "";
     setParticipantId(participantID);
   }, [participantId]);
 
+  
   useEffect(() => {
+    const interval = 100;
+ 
     function progress() {
-      setTimeLeftAsAPercentage((oldCompleted) => {
-        return Math.max(oldCompleted - 10, 0);
-      });
+      if(!answerSubmitted){
+        setTimeLeftAsAPercentage((oldCompleted) => {
+          let increment = 100*(Date.now() - startTime)/(totalTimeInSeconds*1000)
+          return Math.max(100 - increment, 0);
+          //return Math.max(oldCompleted - 1, 0);
+        });
+      }
     }
-    const timer = setInterval(progress, 1000);
+    const timer = setInterval(progress, interval);
 
     return () => {
       clearInterval(timer);
@@ -133,6 +145,9 @@ export default function QuestionResponder() {
                 message.questionNumber,
               ),
             );
+            setTotalTimeInSeconds(120);
+            setStartTime(Date.now());
+            setAnswerSubmitted(false);
             setTimeLeftAsAPercentage(100);
             setAnswer("");
             setButtonDisabled(false);
@@ -172,6 +187,7 @@ export default function QuestionResponder() {
           <QuizQuestionDisplay
             quizQuestion={quizQuestion}
             timeLeftAsAPercentage={timeLeftAsAPercentage}
+            totalTimeInSeconds={totalTimeInSeconds}
           />
           <Paper elevation={1} className={classes.answer}>
             <TextField


### PR DESCRIPTION
Added the following changes
- Increased answer time to 120 seconds, currently hardcoded but eventually will be an option
- Remaining response times displayed on screen of participant
- Remaining response times displayed on quiz master screen
- Remaining response times used to allocate bonus point to fastest answer

resolves #12 
resolves #13 