### PR TITLE
fix(webapp): fixed ability to join quiz using code from homepage

### DIFF
--- a/quizmaster-client-app/src/components/HomePage/HomePage.tsx
+++ b/quizmaster-client-app/src/components/HomePage/HomePage.tsx
@@ -82,11 +82,11 @@ function HomePage() {
 
   const onJoinQuizSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    Axios.get(`/api/quizzes/${quizCode}`).then((res) => {
+    Axios.get(`/api/quizzes/${quizCode}/name`).then((res) => {
       if (!res.data) {
         setOpen(true);
       } else {
-        history.push(`/quiz/${res.data.code}/${res.data.name.toUrlFormat()}`);
+        history.push(`/quiz/${quizCode}/${res.data.toUrlFormat()}`);
       }
     });
   };

--- a/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
@@ -117,10 +117,13 @@ export default function QuizWizard() {
         <Typography component="h1" variant="h4">
           {quizName}
         </Typography>
+        <Typography component="h1" variant="h5">
+          Quiz Joining Code: {id}
+        </Typography>
       </Box>
       <Box pt={3} pb={3}>
         <Typography variant="body2" gutterBottom>
-          Give your friends the link to let them join:{" "}
+          Or simply give your friends the link to let them join:{" "}
           {quizName ? (
             <a data-testid="quiz-url" href={getQuizUrl()}>
               {getQuizUrl()}


### PR DESCRIPTION
- Changed join quiz API call to {id}/name  which doesn't require authorisation 

- Added text on Quizmaster wizard to display the quiz code to be provided to the user

![Screenshot 2020-12-06 020004](https://user-images.githubusercontent.com/29126973/101269435-d8e4d780-3766-11eb-9879-70bf449f637a.png)

fixes #59 
