### PR TITLE
Make app bar fixed instead of sticky

### DIFF
--- a/quizmaster-client-app/src/components/Common/Header.tsx
+++ b/quizmaster-client-app/src/components/Common/Header.tsx
@@ -53,7 +53,7 @@ export default function Header() {
 
   return (
     <>
-      <AppBar position="sticky">
+      <AppBar position="fixed">
         <Toolbar variant="dense">
           <IconButton
             aria-label="contact"


### PR DESCRIPTION
Make app bar fixed instead of sticky so the app bar's dimensions don't impact the rest of the page.

See the documentation here: https://material-ui.com/components/app-bar/#fixed-placement

closes #76 