### PR TITLE
feat(webapp): Allow Participant to refresh page and rejoin quiz

### DIFF
--- a/QuizMaster.Api/Controllers/QuizzesController.cs
+++ b/QuizMaster.Api/Controllers/QuizzesController.cs
@@ -54,8 +54,20 @@ namespace TodoApi.Controllers
             return Ok(mediator.Send(new Details.Query(id)).Result.Name);
         }
 
+        [HttpGet("{id}/details/{participantId}")]
+        public async Task<ActionResult<Details.ParticipantQuizDetails>> GetParticipantQuizDetails(string id, Guid participantId)
+        {
+            var quizDetails = await mediator.Send(new Details.ParticipantQuery(id,participantId));
+
+            if (quizDetails == null)
+            {
+                return NotFound();
+            }
+            return Ok(quizDetails);
+        }        
+
         [HttpGet("{id}/state")]
-        public async Task<ActionResult<String>> GetQuizState(string id)
+        public async Task<ActionResult<Details.QuizStateValues>> GetQuizState(string id)
         {
             var quiz = await mediator.Send(new Details.Query(id));
 
@@ -64,7 +76,9 @@ namespace TodoApi.Controllers
                 return NotFound();
             }
 
-            return Ok(new Details.QuizStateValues(){QuizState = quiz.State, QuestionNo = quiz.QuestionNo});
+            return Ok(new Details.QuizStateValues(){
+                QuizState = quiz.State, QuestionNo = quiz.QuestionNo, QuestionStartTime = quiz.QuestionStartTime
+                });
         }        
 
         [ServiceFilter(typeof(ApiKeyAuthAttribute))]

--- a/QuizMaster.Application/Quizzes/Details.cs
+++ b/QuizMaster.Application/Quizzes/Details.cs
@@ -22,11 +22,33 @@ namespace QuizMaster.Application.Quizzes
             public string QuizCode { get; private set; }
         }
 
+        public class ParticipantQuery : IRequest<ParticipantQuizDetails>
+        {
+            public ParticipantQuery(string quizCode, Guid participantId)
+            {
+                this.QuizCode = quizCode;
+                this.ParticipantId = participantId;
+            }
+
+            public string QuizCode { get; private set; }
+            public Guid ParticipantId { get; private set; }
+        } 
+
+        public class ParticipantQuizDetails
+        {
+            public string QuizName { get; set; }
+            public QuizState? QuizState { get; set; }
+            public int? QuestionNo { get; set; }
+            public long? QuestionStartTime { get; set; }
+            public string Question { get; set; }
+        }               
+
         public class QuizStateValues
         {
             public QuizState? QuizState { get; set; }
-            public int? QuestionNo { get; set;}
-        }        
+            public int? QuestionNo { get; set; }
+            public long QuestionStartTime { get; set; }
+        }
 
         public class Handler : IRequestHandler<Query, Quiz>
         {
@@ -43,5 +65,44 @@ namespace QuizMaster.Application.Quizzes
                 return quiz;
             }
         }
+
+        public class ParticipantQueryHandler : IRequestHandler<ParticipantQuery, ParticipantQuizDetails>
+        {
+            private readonly QuizContext context;
+
+            public ParticipantQueryHandler(QuizContext context)
+            {
+                this.context = context;
+            }
+
+            public async Task<ParticipantQuizDetails> Handle(ParticipantQuery request, CancellationToken cancellationToken)
+            {
+                var quiz = await context.Quiz.Include(x => x.Contestants).Include(x => x.QuizQuestions).SingleOrDefaultAsync(x => x.Code == request.QuizCode);
+                if(quiz == null)
+                {
+                    return null;
+                }
+                if(quiz.Contestants.Find(x => x.Id == request.ParticipantId) == null)
+                {
+                    return null;
+                }
+                else
+                {
+                    var question = "";
+                    if(quiz.State==QuizMaster.Domain.QuizState.QuestionInProgress)
+                    {
+                        question = quiz.QuizQuestions.Find(x => x.Number == quiz.QuestionNo).Question;
+                    }
+                    return new ParticipantQuizDetails()
+                        {
+                            QuizName = quiz.Name,
+                            QuizState = quiz.State,
+                            QuestionNo = quiz.QuestionNo,
+                            QuestionStartTime = quiz.QuestionStartTime,
+                            Question = question,
+                        };
+                }
+            }
+        }        
     }
 }

--- a/QuizMaster.Application/Quizzes/Update.cs
+++ b/QuizMaster.Application/Quizzes/Update.cs
@@ -26,6 +26,7 @@ namespace QuizMaster.Application.Quizzes
         {
             public QuizState? QuizState { get; set; }
             public int? QuestionNo { get; set;}
+            public long? QuestionStartTime { get; set;}
         }        
 
         public class Handler : IRequestHandler<Command, Quiz>
@@ -45,6 +46,9 @@ namespace QuizMaster.Application.Quizzes
                 if(request.CommandBody.QuizState.HasValue){
                     quiz.State = request.CommandBody.QuizState.Value;
                 }
+                if(request.CommandBody.QuestionStartTime.HasValue){
+                    quiz.QuestionStartTime = request.CommandBody.QuestionStartTime.Value;
+                }                
                 if(context.ChangeTracker.HasChanges())
                 {
                     var success = await context.SaveChangesAsync() > 0;

--- a/QuizMaster.Domain/Quiz.cs
+++ b/QuizMaster.Domain/Quiz.cs
@@ -14,6 +14,7 @@ namespace QuizMaster.Domain
             this.Key = GenerateKey();
             this.State = QuizState.QuizNotStarted;
             this.QuestionNo = 0;
+            this.QuestionStartTime = 0;
         }
 
         public Quiz(Guid id, String name, String code)
@@ -28,6 +29,7 @@ namespace QuizMaster.Domain
         public String Key { get; private set; }
         public QuizState State { get; set; }
         public int QuestionNo { get; set; }
+        public long QuestionStartTime { get; set; }
         public List<Contestant> Contestants { get; set; }
         public List<QuizQuestion> QuizQuestions { get; set; }
 

--- a/QuizMaster.Persistence/Migrations/20201229151509_QuestionStartTime.Designer.cs
+++ b/QuizMaster.Persistence/Migrations/20201229151509_QuestionStartTime.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizMaster.Persistence;
 
 namespace QuizMaster.Persistence.Migrations
 {
     [DbContext(typeof(QuizContext))]
-    partial class QuizContextModelSnapshot : ModelSnapshot
+    [Migration("20201229151509_QuestionStartTime")]
+    partial class QuestionStartTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizMaster.Persistence/Migrations/20201229151509_QuestionStartTime.cs
+++ b/QuizMaster.Persistence/Migrations/20201229151509_QuestionStartTime.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizMaster.Persistence.Migrations
+{
+    public partial class QuestionStartTime : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "QuestionStartTime",
+                table: "Quiz",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "QuestionStartTime",
+                table: "Quiz");
+        }
+    }
+}

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -67,6 +67,14 @@ export default function QuizHoster() {
   const updateQuizStateInProgress = () => {
     axios.post(`/api/quizzes/${id}`, {
       QuizState: QuizState.QuestionInProgress,
+      QuestionStartTime: Date.now(),
+    });
+  };
+
+  const updateQuizStatePendingResults = () => {
+    axios.post(`/api/quizzes/${id}`, {
+      QuestionNo: 0,
+      QuizState: QuizState.QuestionReady,
     });
   };
 
@@ -101,6 +109,7 @@ export default function QuizHoster() {
       .post(`/api/quizzes/${id}`, {
         QuestionNo: 1,
         QuizState: QuizState.QuestionInProgress,
+        QuestionStartTime: Date.now(),
       })
       .then(() => {
         messageContestants();
@@ -134,7 +143,7 @@ export default function QuizHoster() {
         .post(`/api/quizzes/${id}/command/quizmastermessage`, message)
         .then(() => {
           setQuizIsComplete(true);
-          //updateQuizStateFinished();
+          updateQuizStateFinished();
         });
     } else {
       setShowQuizMarker(true);
@@ -189,7 +198,7 @@ export default function QuizHoster() {
     );
     setShowQuizMarker(false);
     if (isFinalQuestion()) {
-      updateQuizStateFinished();
+      updateQuizStatePendingResults();
     } else {
       updateQuizStateReady();
     }


### PR DESCRIPTION
When Participant refreshes the page during a quiz they will rejoin if a question is in progress and be able to answer the question.  

Added the QuestionStartTime to the Quiz persistence table 

Added an API  /quizzes/{id}/details/{participantId}  which verifies that the participant has joined the quiz and if so gives them details needed to rejoin such as name, state, current question number and question start time. 

Resolves #88 


