### PR TITLE
Stop participant's connection from reconnecting

### DIFF
--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -178,18 +178,6 @@ export default function QuestionResponder() {
     const createHubConnection = async () => {
       // Build new Hub Connection, url is currently hard coded.
       const hubConnect = new HubConnectionBuilder()
-        .withAutomaticReconnect([
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-          1000,
-        ])
         .withUrl(process.env.REACT_APP_BASE_API_URL + "/quiz")
         .configureLogging("trace")
         .build();


### PR DESCRIPTION
Some devices end up in a broken connected state - don't automatically reconnect, a user should reconnect via the modal by clicking 'refresh' - it needs to be explicit closes #87 