### PR TITLE
Feature/improved question transitions

### DIFF
--- a/QuizMaster.Api/Postman Tests/Quiz Master API Tests.postman_collection.json
+++ b/QuizMaster.Api/Postman Tests/Quiz Master API Tests.postman_collection.json
@@ -231,7 +231,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"Start\": false,\r\n    \"Complete\": true,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1\r\n}",
+					"raw": "{\r\n    \"State\": 2,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1,\r\n    \"Kicked\": false,\r\n    \"Standings\": []\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -280,7 +280,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"Start\": false,\r\n    \"Complete\": true,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1\r\n}",
+					"raw": "{\r\n    \"State\": 2,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1,\r\n    \"Kicked\": false,\r\n    \"Standings\": []\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -329,7 +329,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"Start\": false,\r\n    \"Complete\": true,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1\r\n}",
+					"raw": "{\r\n    \"State\": 2,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1,\r\n    \"Kicked\": false,\r\n    \"Standings\": []\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -378,7 +378,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"Start\": false,\r\n    \"Complete\": true,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1\r\n}",
+					"raw": "{\r\n    \"State\": 2,\r\n    \"Question\": \"Test question.\",\r\n    \"Answer\": \"Test answer.\",\r\n    \"QuestionNumber\": 1,\r\n    \"Kicked\": false,\r\n    \"Standings\": []\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/QuizMaster.Application/QuizMasterMessage.cs
+++ b/QuizMaster.Application/QuizMasterMessage.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
+using QuizMaster.Domain;
 
 namespace QuizMaster.Application
 {
     public class QuizMasterMessage
     {
-        public bool Start { get; set; }
-        public bool Complete { get; set; }
+        public QuizState State { get; set; }
         public string Question { get; set; }
         public string Answer { get; set; }
         public int QuestionNumber { get; set; }

--- a/QuizMaster.Domain/QuizState.cs
+++ b/QuizMaster.Domain/QuizState.cs
@@ -3,8 +3,10 @@ namespace QuizMaster.Domain
     public enum QuizState
     {
         QuizNotStarted,
-        QuestionReady,
+        FirstQuestionReady,
         QuestionInProgress,
+        NextQuestionReady,
+        ResultsReady,
         QuizEnded,
     }
 }

--- a/quizmaster-client-app/src/components/Common/QuizMasterMessage.ts
+++ b/quizmaster-client-app/src/components/Common/QuizMasterMessage.ts
@@ -1,8 +1,8 @@
 import Contestant from "../QuizHosting/Contestant";
+import QuizState from "./QuizState";
 
 interface QuizMasterMessage {
-  start: boolean;
-  complete: boolean;
+  state: QuizState;
   question: string;
   answer: string;
   questionNumber: number;

--- a/quizmaster-client-app/src/components/Common/QuizState.ts
+++ b/quizmaster-client-app/src/components/Common/QuizState.ts
@@ -1,7 +1,9 @@
 enum QuizState {
   QuizNotStarted,
-  QuestionReady,
+  FirstQuestionReady,
   QuestionInProgress,
+  NextQuestionReady,
+  ResultsReady,
   QuizEnded,
 }
 

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
@@ -412,7 +412,7 @@ export default function QuestionMarker(props: {
             onClick={onAcceptAnswers}
           >
             <DoneIcon className={fabClasses.extendedIcon} />
-            Continue to next question
+            Calculate Scores and prepare next question
           </Fab>
         </Zoom>
       </TableContainer>

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionMarker.tsx
@@ -412,7 +412,7 @@ export default function QuestionMarker(props: {
             onClick={onAcceptAnswers}
           >
             <DoneIcon className={fabClasses.extendedIcon} />
-            Calculate Scores and prepare next question
+            Calculate scores and prepare next question
           </Fab>
         </Zoom>
       </TableContainer>

--- a/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
@@ -146,7 +146,7 @@ export default function QuizWizard() {
       axios
         .post(`/api/quizzes/${id}`, {
           QuestionNo: 1,
-          QuizState: QuizState.QuestionReady,
+          QuizState: QuizState.FirstQuestionReady,
         })
         .then(() => {
           history.push(`/quiz/${id}/${quizName}/host`);

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -212,7 +212,6 @@ export default function QuestionResponder() {
             setQuizIsComplete(true);
             setQuizState(message.state);
           } else {
-            //QuizState.QuestionInProgress
             setQuizQuestion(
               new QuizQuestion(
                 message.question,

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -56,7 +56,6 @@ export default function QuestionResponder() {
   const [quizName, setQuizName] = useState<string>("");
   const [answer, setAnswer] = useState<string>("");
   const [quizQuestion, setQuizQuestion] = useState<QuizQuestion>();
-  const [quizInitialized, setQuizInitialized] = useState<boolean>(false);
   const [buttonDisabled, setButtonDisabled] = useState<boolean>(false);
   const [timeLeftAsAPercentage, setTimeLeftAsAPercentage] = useState<number>(0);
   const [quizIsComplete, setQuizIsComplete] = useState<boolean>(false);
@@ -73,10 +72,11 @@ export default function QuestionResponder() {
   const [pageError, setPageError] = useState(false);
   const [pageLoading, setPageLoading] = useState(true);
   const [questionNo, setQuestionNo] = useState(0);
-  const [awaitingFinalScores, setAwaitingFinalScores] = useState(false);
   const [disconnectedDialogOpen, setDisconnectedDialogOpen] = useState<boolean>(
     false,
   );
+  const [quizState, setQuizState] = useState(QuizState.QuizNotStarted);
+
   const apiBaseUrl = process.env.REACT_APP_BASE_API_URL;
 
   const onAnswerChange = (e: ChangeEvent<HTMLInputElement>) =>
@@ -145,12 +145,7 @@ export default function QuestionResponder() {
         setPageLoading(false);
         setQuizName(res.data.quizName);
         setQuestionNo(res.data.questionNo);
-        if (
-          res.data.quizState == QuizState.QuestionReady &&
-          res.data.questionNo > 0
-        ) {
-          setQuizInitialized(true);
-        } else if (res.data.quizState == QuizState.QuestionInProgress) {
+        if (res.data.quizState == QuizState.QuestionInProgress) {
           setQuizQuestion(
             new QuizQuestion(res.data.question, "", res.data.questionNo),
           );
@@ -169,11 +164,6 @@ export default function QuestionResponder() {
             setButtonDisabled(false);
             setSubmitText("Submit");
           }
-        } else if (
-          res.data.questionNo == 0 &&
-          res.data.quizState == QuizState.QuestionReady
-        ) {
-          setAwaitingFinalScores(true);
         } else if (res.data.quizState == QuizState.QuizEnded) {
           const newContestantStandings = res.data.contestantScores.map(
             (contestant: any) => {
@@ -187,6 +177,7 @@ export default function QuestionResponder() {
           setContestantStandings(newContestantStandings);
           setQuizIsComplete(true);
         }
+        setQuizState(res.data.quizState);
       })
       .catch(() => {
         setPageError(true);
@@ -202,18 +193,26 @@ export default function QuestionResponder() {
 
       try {
         hubConnect.on("ContestantUpdate", (message: QuizMasterMessage) => {
-          if (message.start) {
-            setQuizInitialized(true);
-            setQuestionNo(message.questionNumber);
-          } else if (message.complete) {
-            setContestantStandings(message.standings);
-            setQuizIsComplete(true);
-          } else if (message.kick) {
+          if (message.kick) {
             console.log("Leaving group...");
             hubConnect.invoke("RemoveFromGroup", quizId);
             console.log("Connection removed.");
             setKicked(true);
+          } else if (message.state == QuizState.FirstQuestionReady) {
+            setQuestionNo(message.questionNumber);
+            setQuizState(message.state);
+          } else if (message.state == QuizState.NextQuestionReady) {
+            setQuestionNo(message.questionNumber);
+            setQuizState(message.state);
+          } else if (message.state == QuizState.ResultsReady) {
+            setQuestionNo(0);
+            setQuizState(message.state);
+          } else if (message.state == QuizState.QuizEnded) {
+            setContestantStandings(message.standings);
+            setQuizIsComplete(true);
+            setQuizState(message.state);
           } else {
+            //QuizState.QuestionInProgress
             setQuizQuestion(
               new QuizQuestion(
                 message.question,
@@ -229,6 +228,7 @@ export default function QuestionResponder() {
             setAnswer("");
             setButtonDisabled(false);
             setSubmitText("Submit");
+            setQuizState(message.state);
           }
         });
       } catch (err) {
@@ -262,10 +262,11 @@ export default function QuestionResponder() {
   return (
     <>
       <Typography component="h2" variant="h5">
-        {!quizIsComplete
-          ? quizInitialized && !quizQuestion
-            ? "You're all set..."
-            : quizName
+        {quizState == QuizState.FirstQuestionReady ||
+        quizState == QuizState.NextQuestionReady
+          ? "You're all set..."
+          : quizState != QuizState.QuizEnded
+          ? quizName
           : ""}
       </Typography>
 
@@ -295,17 +296,18 @@ export default function QuestionResponder() {
             <QuizStandings contestantStandings={contestantStandings} />
           </div>
         </>
-      ) : quizInitialized && !quizQuestion ? (
+      ) : quizState === QuizState.FirstQuestionReady ||
+        quizState === QuizState.NextQuestionReady ? (
         <Box mb={2}>
           <p>Get ready for question {questionNo}</p>
           <LinearProgress />
         </Box>
-      ) : awaitingFinalScores ? (
+      ) : quizState === QuizState.ResultsReady ? (
         <Box mb={2}>
           <p>Get ready for the final scores</p>
           <LinearProgress />
         </Box>
-      ) : quizQuestion ? (
+      ) : quizState === QuizState.QuestionInProgress ? (
         <>
           <QuizQuestionDisplay
             quizQuestion={quizQuestion}


### PR DESCRIPTION
Now a message is sent to participants when Quiz Master clicks to calculate scores , this allows participant to get ready for question timer start instead of jumping from 1 question to the other. 

Also improved wording on buttons and display to better describe what is happening.  

Extended QuizState enum to better describe each of the states

Previous logic required combination of state + question number  e.g.  state=QuestionReady and questionNo=0 means final standings are ready,  replaced with ResultsReady

Made code more readable with regard to rendering depending on the state

Resolves #91 