### PR TITLE
Fixed duplicate test attribute and fixed quiz joiner logic

### DIFF
--- a/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizWizard.tsx
@@ -240,7 +240,7 @@ export default function QuizWizard() {
               following link:
               <div>
                 {quizName ? (
-                  <a data-testid="quiz-url" href={getQuizMasterUrl()}>
+                  <a data-testid="quiz-master-url" href={getQuizMasterUrl()}>
                     {getQuizMasterUrl()}
                   </a>
                 ) : null}

--- a/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
@@ -82,13 +82,9 @@ export default function QuizJoiner() {
 
     // The user has been, or is a participant, let's check if they're a participant of this quiz.
     if (participantID) {
-      axios.get(`/api/quizzes/${id}/details/${participantID}`).then((res) => {
-        // They are a participant of this quiz, so let's check if the quiz is in progress.
-        if (res.data.quizState == 1 || res.data.quizState == 2) {
-          // The quiz is in progress, let's help them get back into the action!
-          setQuizForParticipantAlreadyInProgress(true);
-          setName(participantName);
-        }
+      axios.get(`/api/quizzes/${id}/details/${participantID}`).then(() => {
+        setQuizForParticipantAlreadyInProgress(true);
+        setName(participantName);
       });
     }
 


### PR DESCRIPTION
When using cypress for end to end tests, data attributed like this: `data-testid="quiz-master-url"` are used for targeting elements on the page, these are used so that the tests don't depend on attributes that might change. closes #44 