### PR TITLE
Feature/improved final standings

### DIFF
--- a/QuizMaster.Api/Controllers/ContestantsController.cs
+++ b/QuizMaster.Api/Controllers/ContestantsController.cs
@@ -70,7 +70,7 @@ namespace TodoApi.Controllers
         [HttpPost("updates")]
         public async Task<ActionResult<List<Contestant>>> UpdateMultiple(List<Update.Command> commandList)
         {
-            var contestants = await mediator.Send(new Update.CommandList(){Commands = commandList});
+            var contestants = await mediator.Send(new Update.CommandList() { Commands = commandList });
 
             if (contestants == null)
             {
@@ -90,6 +90,19 @@ namespace TodoApi.Controllers
         [HttpDelete("{id}")]
         public void Delete(int id)
         {
+        }
+
+        [HttpGet("{id}/finalsummary")]
+        public async Task<ActionResult<Contestant>> GetFinalSummary(Guid id)
+        {
+            var summary = await mediator.Send(new QuizMaster.Application.Contestants.FinalSummary.Query(id));
+
+            if (summary == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(summary);
         }
     }
 }

--- a/QuizMaster.Api/Controllers/QuizzesController.cs
+++ b/QuizMaster.Api/Controllers/QuizzesController.cs
@@ -127,6 +127,27 @@ namespace TodoApi.Controllers
             return Ok();
         }
 
+        [ServiceFilter(typeof(ApiKeyAuthAttribute))]
+        [HttpPost("{id}/updatecontestantanswers")]
+        public async Task<ActionResult<List<Contestant>>> UpdateContestantAnswers(QuizMaster.Application.ContestantAnswers.Update.RequestBody requestBody, string id)
+        {
+            var contestants = await mediator.Send(
+                new QuizMaster.Application.ContestantAnswers.Update.Command()
+                {
+                    QuizCode = id,
+                    QuestionNo = requestBody.QuestionNo,
+                    AnswerUpdates = requestBody.AnswerUpdates
+                }
+            );
+
+            if (contestants == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(contestants);
+        }
+
         // POST api/values
         [HttpPost]
         public async Task<ActionResult<Quiz>> Post(Create.Command command)

--- a/QuizMaster.Application/ContestantAnswers/Create.cs
+++ b/QuizMaster.Application/ContestantAnswers/Create.cs
@@ -16,14 +16,14 @@ namespace QuizMaster.Application.ContestantAnswers
             [Required]
             public string QuizCode { get; set; }
             [Required]
-            public int QuestionNumber { get; set; }               
+            public int QuestionNumber { get; set; }
             [Required]
             public Guid ContestantId { get; set; }
- 
+
             [Required]
-            public string Answer { get; set; }    
+            public string Answer { get; set; }
             [Required]
-            public long TimeRemainingMs { get; set; }   
+            public long TimeRemainingMs { get; set; }
             [Required]
             public float PercentageTimeRemaining { get; set; }
 
@@ -35,7 +35,7 @@ namespace QuizMaster.Application.ContestantAnswers
                 this.Answer = answer;
                 this.TimeRemainingMs = timeRemainingMs;
                 this.PercentageTimeRemaining = percentageTimeRemaining;
-            }                                                       
+            }
         }
 
         public class Handler : IRequestHandler<Command, ContestantAnswer>
@@ -62,8 +62,8 @@ namespace QuizMaster.Application.ContestantAnswers
                 if (question == null)
                 {
                     return null;
-                } 
-                var contestantAnswer = new ContestantAnswer(question.Id,contestant.Id,request.Answer,request.TimeRemainingMs,request.PercentageTimeRemaining);
+                }
+                var contestantAnswer = new ContestantAnswer(question.Id, contestant.Id, request.Answer, request.TimeRemainingMs, request.PercentageTimeRemaining, false, false, 0, 0);
                 context.ContestantAnswers.Add(contestantAnswer);
 
                 var success = await context.SaveChangesAsync() > 0;

--- a/QuizMaster.Application/ContestantAnswers/Update.cs
+++ b/QuizMaster.Application/ContestantAnswers/Update.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using QuizMaster.Domain;
+using QuizMaster.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace QuizMaster.Application.ContestantAnswers
+{
+    public class Update
+    {
+        public class Command : IRequest<List<ContestantAnswer>>
+        {
+            [Required]
+            public string QuizCode { get; set; }
+            [Required]
+            public int QuestionNo { get; set; }
+
+            [Required]
+            public List<UpdateValues> AnswerUpdates { get; set; }
+        }
+
+        public class RequestBody
+        {
+            [Required]
+            public int QuestionNo { get; set; }
+            public List<UpdateValues> AnswerUpdates { get; set; }
+        }
+
+        public class UpdateValues
+        {
+            public Guid ContestantId { get; set; }
+            public bool Correct { get; set; }
+            public bool Fastest { get; set; }
+            public int BonusPoints { get; set; }
+            public int Score { get; set; }
+        }
+
+        public class ListHandler : IRequestHandler<Command, List<ContestantAnswer>>
+        {
+            private readonly QuizContext context;
+            public ListHandler(QuizContext context)
+            {
+                this.context = context;
+            }
+
+            public async Task<List<ContestantAnswer>> Handle(Command request, CancellationToken cancellationToken)
+            {
+
+                var quiz = await context.Quiz.Include(x => x.QuizQuestions).SingleOrDefaultAsync(x => x.Code == request.QuizCode);
+                if (quiz == null)
+                {
+                    return null;
+                }
+                var quizQuestion = quiz.QuizQuestions.Find(x => x.Number == request.QuestionNo);
+                if (quizQuestion == null)
+                {
+                    return null;
+                }
+
+                var contestantAnswers = new List<ContestantAnswer>();
+                foreach (UpdateValues command in request.AnswerUpdates)
+                {
+                    var contestantAnswer = context.ContestantAnswers.SingleOrDefault(x => (x.ContestantId == command.ContestantId && x.QuizQuestionId == quizQuestion.Id));
+                    if (contestantAnswer == null)
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        contestantAnswer.Correct = command.Correct;
+                        contestantAnswer.Fastest = command.Fastest;
+                        contestantAnswer.BonusPoints = command.BonusPoints;
+                        contestantAnswer.Score = command.Score;
+                        contestantAnswers.Add(contestantAnswer);
+                    }
+                }
+                if (context.ChangeTracker.HasChanges())
+                {
+                    var success = await context.SaveChangesAsync() > 0;
+                    if (success)
+                    {
+                        return contestantAnswers;
+                    }
+                }
+                else
+                {
+                    return contestantAnswers;
+                }
+
+                throw new Exception("There was a problem saving changes.");
+            }
+        }
+    }
+}

--- a/QuizMaster.Application/ContestantScore.cs
+++ b/QuizMaster.Application/ContestantScore.cs
@@ -5,5 +5,6 @@ namespace QuizMaster.Application
         public string Id { get; set; }
         public string Name { get; set; }
         public int Score { get; set; }
+        public int BonusPoints { get; set; }
     }
 }

--- a/QuizMaster.Application/Contestants/FinalSummary.cs
+++ b/QuizMaster.Application/Contestants/FinalSummary.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using QuizMaster.Domain;
+using QuizMaster.Persistence;
+
+namespace QuizMaster.Application.Contestants
+{
+    public class FinalSummary
+    {
+        public class Query : IRequest<List<QuestionSummary>>
+        {
+            public Query(Guid id)
+            {
+                Id = id;
+            }
+
+            public Guid Id { get; private set; }
+        }
+
+        public class QuestionSummary
+        {
+            public int Number { get; set; }
+            public string Question { get; set; }
+            public string CorrectAnswer { get; set; }
+            public string ContestantAnswer { get; set; }
+            public string FastestContestantName { get; set; }
+            public bool ContestantIsFastest { get; set; }
+            public int Score { get; set; }
+        }
+
+        public class Handler : IRequestHandler<Query, List<QuestionSummary>>
+        {
+            private readonly QuizContext context;
+
+            public Handler(QuizContext context)
+            {
+                this.context = context;
+            }
+
+            public async Task<List<QuestionSummary>> Handle(Query request, CancellationToken cancellationToken)
+            {
+                var contestant = await context.Contestants.Include(x => x.ContestantAnswers).SingleOrDefaultAsync(x => x.Id == request.Id);
+                if (contestant == null)
+                {
+                    return null;
+                }
+
+                var quiz = await context.Quiz.Include("QuizQuestions.ContestantAnswers").SingleOrDefaultAsync(x => x.Id == contestant.QuizId);
+                if (quiz == null)
+                {
+                    return null;
+                }
+                else if (quiz.State != QuizState.QuizEnded)
+                {
+                    return null;
+                }
+
+                var questionSummaries = new List<QuestionSummary>();
+
+                foreach (QuizQuestion question in quiz.QuizQuestions)
+                {
+                    //var questionNo = question.Number
+                    //var answerText = 
+                    var contestantAnswerText = "";
+                    var contestantIsFastest = false;
+                    var score = 0;
+                    var fastestContestantName = "";
+
+                    var contestantAnswer = question.ContestantAnswers.Find(x => x.ContestantId == contestant.Id);
+                    if (contestantAnswer != null)
+                    {
+                        contestantAnswerText = contestantAnswer.Answer;
+                        contestantIsFastest = contestantAnswer.Fastest;
+                        score = contestantAnswer.Score;
+                    }
+                    if (!contestantIsFastest)
+                    {
+                        var fastestContestantAnswer = question.ContestantAnswers.Find(x => x.Fastest == true);
+                        if (fastestContestantAnswer != null)
+                        {
+                            var fastestContestant = await context.Contestants.SingleOrDefaultAsync(x => x.Id == fastestContestantAnswer.ContestantId);
+                            fastestContestantName = fastestContestant.Name;
+                        }
+                        else
+                        {
+                            fastestContestantName = "";
+                        }
+                    }
+                    else
+                    {
+                        fastestContestantName = contestant.Name;
+                    }
+
+                    questionSummaries.Add(
+                        new QuestionSummary
+                        {
+                            Number = question.Number,
+                            Question = question.Question,
+                            CorrectAnswer = question.Answer,
+                            ContestantAnswer = contestantAnswerText,
+                            FastestContestantName = fastestContestantName,
+                            ContestantIsFastest = contestantIsFastest,
+                            Score = score,
+                        }
+                    );
+                }
+                return questionSummaries;
+            }
+        }
+    }
+}

--- a/QuizMaster.Application/Contestants/FinalSummary.cs
+++ b/QuizMaster.Application/Contestants/FinalSummary.cs
@@ -49,7 +49,7 @@ namespace QuizMaster.Application.Contestants
                     return null;
                 }
 
-                var quiz = await context.Quiz.Include("QuizQuestions.ContestantAnswers").SingleOrDefaultAsync(x => x.Id == contestant.QuizId);
+                var quiz = await context.Quiz.Include(x => x.QuizQuestions).ThenInclude(y => y.ContestantAnswers).SingleOrDefaultAsync(x => x.Id == contestant.QuizId);
                 if (quiz == null)
                 {
                     return null;

--- a/QuizMaster.Application/Contestants/FinalSummary.cs
+++ b/QuizMaster.Application/Contestants/FinalSummary.cs
@@ -63,8 +63,6 @@ namespace QuizMaster.Application.Contestants
 
                 foreach (QuizQuestion question in quiz.QuizQuestions)
                 {
-                    //var questionNo = question.Number
-                    //var answerText = 
                     var contestantAnswerText = "";
                     var contestantIsFastest = false;
                     var score = 0;
@@ -84,10 +82,6 @@ namespace QuizMaster.Application.Contestants
                         {
                             var fastestContestant = await context.Contestants.SingleOrDefaultAsync(x => x.Id == fastestContestantAnswer.ContestantId);
                             fastestContestantName = fastestContestant.Name;
-                        }
-                        else
-                        {
-                            fastestContestantName = "";
                         }
                     }
                     else

--- a/QuizMaster.Application/Contestants/Update.cs
+++ b/QuizMaster.Application/Contestants/Update.cs
@@ -23,13 +23,14 @@ namespace QuizMaster.Application.Contestants
 
         public class CommandList : IRequest<List<Contestant>>
         {
-        [Required]
-        public List<Command> Commands { get; set; }
-        }        
+            [Required]
+            public List<Command> Commands { get; set; }
+        }
 
         public class CommandBody : IRequest<Contestant>
         {
             public int? Score { get; set; }
+            public int? BonusPoints { get; set; }
         }
 
         public class Handler : IRequestHandler<Command, Contestant>
@@ -51,6 +52,10 @@ namespace QuizMaster.Application.Contestants
                 if (request.Update.Score.HasValue)
                 {
                     contestant.Score = request.Update.Score.Value;
+                }
+                if (request.Update.BonusPoints.HasValue)
+                {
+                    contestant.BonusPoints = request.Update.BonusPoints.Value;
                 }
 
                 if (context.ChangeTracker.HasChanges())
@@ -89,6 +94,10 @@ namespace QuizMaster.Application.Contestants
                         if (command.Update.Score.HasValue)
                         {
                             contestant.Score = command.Update.Score.Value;
+                        }
+                        if (command.Update.BonusPoints.HasValue)
+                        {
+                            contestant.BonusPoints = command.Update.BonusPoints.Value;
                         }
                         contestants.Add(contestant);
                     }

--- a/QuizMaster.Domain/Contestant.cs
+++ b/QuizMaster.Domain/Contestant.cs
@@ -11,6 +11,7 @@ namespace QuizMaster.Domain
             this.QuizId = quizId;
             Name = name;
             Score = 0;
+            BonusPoints = 0;
         }
 
         public Guid Id { get; private set; }
@@ -19,5 +20,6 @@ namespace QuizMaster.Domain
         public Guid QuizId { get; set; }
         public List<ContestantAnswer> ContestantAnswers { get; set; }
         public int Score { get; set; }
+        public int BonusPoints { get; set; }
     }
 }

--- a/QuizMaster.Domain/ContestantAnswer.cs
+++ b/QuizMaster.Domain/ContestantAnswer.cs
@@ -4,13 +4,17 @@ namespace QuizMaster.Domain
 {
     public class ContestantAnswer
     {
-        public ContestantAnswer(Guid quizQuestionId, Guid contestantId, string answer, long timeRemainingMs, float percentageTimeRemaining)
+        public ContestantAnswer(Guid quizQuestionId, Guid contestantId, string answer, long timeRemainingMs, float percentageTimeRemaining, bool correct, bool fastest, int bonusPoints, int score)
         {
             this.QuizQuestionId = quizQuestionId;
             this.ContestantId = contestantId;
             this.Answer = answer;
             this.TimeRemainingMs = timeRemainingMs;
             this.PercentageTimeRemaining = percentageTimeRemaining;
+            this.Correct = correct;
+            this.Fastest = fastest;
+            this.BonusPoints = bonusPoints;
+            this.Score = score;
         }
 
         public Guid Id { get; private set; }
@@ -19,5 +23,9 @@ namespace QuizMaster.Domain
         public String Answer { get; private set; }
         public long TimeRemainingMs { get; private set; }
         public float PercentageTimeRemaining { get; private set; }
+        public bool Correct { get; set; }
+        public bool Fastest { get; set; }
+        public int BonusPoints { get; set; }
+        public int Score { get; set; }
     }
 }

--- a/QuizMaster.Persistence/Migrations/20210110235648_ContestantBonusPoints.Designer.cs
+++ b/QuizMaster.Persistence/Migrations/20210110235648_ContestantBonusPoints.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizMaster.Persistence;
 
 namespace QuizMaster.Persistence.Migrations
 {
     [DbContext(typeof(QuizContext))]
-    partial class QuizContextModelSnapshot : ModelSnapshot
+    [Migration("20210110235648_ContestantBonusPoints")]
+    partial class ContestantBonusPoints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -70,9 +72,6 @@ namespace QuizMaster.Persistence.Migrations
 
                     b.Property<Guid>("QuizQuestionId")
                         .HasColumnType("TEXT");
-
-                    b.Property<int>("Score")
-                        .HasColumnType("INTEGER");
 
                     b.Property<long>("TimeRemainingMs")
                         .HasColumnType("INTEGER");

--- a/QuizMaster.Persistence/Migrations/20210110235648_ContestantBonusPoints.cs
+++ b/QuizMaster.Persistence/Migrations/20210110235648_ContestantBonusPoints.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizMaster.Persistence.Migrations
+{
+    public partial class ContestantBonusPoints : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BonusPoints",
+                table: "Contestants",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BonusPoints",
+                table: "ContestantAnswers",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Correct",
+                table: "ContestantAnswers",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Fastest",
+                table: "ContestantAnswers",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BonusPoints",
+                table: "Contestants");
+
+            migrationBuilder.DropColumn(
+                name: "BonusPoints",
+                table: "ContestantAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "Correct",
+                table: "ContestantAnswers");
+
+            migrationBuilder.DropColumn(
+                name: "Fastest",
+                table: "ContestantAnswers");
+        }
+    }
+}

--- a/QuizMaster.Persistence/Migrations/20210111153831_ContestantAnswerScore.Designer.cs
+++ b/QuizMaster.Persistence/Migrations/20210111153831_ContestantAnswerScore.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizMaster.Persistence;
 
 namespace QuizMaster.Persistence.Migrations
 {
     [DbContext(typeof(QuizContext))]
-    partial class QuizContextModelSnapshot : ModelSnapshot
+    [Migration("20210111153831_ContestantAnswerScore")]
+    partial class ContestantAnswerScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizMaster.Persistence/Migrations/20210111153831_ContestantAnswerScore.cs
+++ b/QuizMaster.Persistence/Migrations/20210111153831_ContestantAnswerScore.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizMaster.Persistence.Migrations
+{
+    public partial class ContestantAnswerScore : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Score",
+                table: "ContestantAnswers",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Score",
+                table: "ContestantAnswers");
+        }
+    }
+}

--- a/quizmaster-client-app/src/components/QuizHosting/Contestant.ts
+++ b/quizmaster-client-app/src/components/QuizHosting/Contestant.ts
@@ -2,6 +2,7 @@ interface Contestant {
   id: string;
   name: string;
   score: number;
+  bonusPoints: number;
 }
 
 export default Contestant;

--- a/quizmaster-client-app/src/components/QuizHosting/ContestantAnswerScore.ts
+++ b/quizmaster-client-app/src/components/QuizHosting/ContestantAnswerScore.ts
@@ -1,0 +1,9 @@
+interface ContestantAnswerScore {
+  ContestantId: string;
+  Correct: boolean;
+  Fastest: boolean;
+  BonusPoints: number;
+  Score: number;
+}
+
+export default ContestantAnswerScore;

--- a/quizmaster-client-app/src/components/QuizHosting/ContestantScore.ts
+++ b/quizmaster-client-app/src/components/QuizHosting/ContestantScore.ts
@@ -1,7 +1,0 @@
-interface ContestantScore {
-  ContestantId: string;
-  ContestantName: string;
-  Score: number;
-}
-
-export default ContestantScore;

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -206,10 +206,10 @@ export default function QuizHoster() {
         kick: false,
         standings: contestants,
       };
+      updateQuizStateFinished();
       axios
         .post(`/api/quizzes/${id}/command/quizmastermessage`, message)
         .then(() => {
-          updateQuizStateFinished();
           setShowQuizMarker(false);
           setCurrentQuizState(QuizState.QuizEnded);
         });

--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -17,7 +17,7 @@ import Data from "./QuestionResponse";
 import ParticipantMessage from "../Common/ParticipantMessage";
 import QuizStandings from "./QuizStandings";
 import QuestionResponse from "./QuestionResponse";
-import ContestantScore from "./ContestantScore";
+import ContestantAnswerScore from "./ContestantAnswerScore";
 import QuizState from "../Common/QuizState";
 
 const useStyles = makeStyles((theme) => ({
@@ -88,10 +88,17 @@ export default function QuizHoster() {
     timeLeftAsAPercentage === 0 || answers.length === contestants.length;
 
   function getContestantScoreForRound(
-    scores: ContestantScore[],
+    scores: ContestantAnswerScore[],
     contestantId: string,
   ): number {
     return scores.find((x) => x.ContestantId == contestantId)?.Score ?? 0;
+  }
+
+  function getContestantBonusPointsForRound(
+    scores: ContestantAnswerScore[],
+    contestantId: string,
+  ): number {
+    return scores.find((x) => x.ContestantId == contestantId)?.BonusPoints ?? 0;
   }
 
   //---------------------------------------------------------------------------
@@ -227,18 +234,23 @@ export default function QuizHoster() {
     });
 
     //Loop through responses to build scores
-    const roundScores: ContestantScore[] = [];
+    const roundScores: ContestantAnswerScore[] = [];
+
     correctResponses.forEach((response) => {
+      let fastest = false;
       let score = 1;
       if (response.id == fastestContestant) {
         score = 2;
+        fastest = true;
       }
-      const contestantScore: ContestantScore = {
+      const contestantAnswerScore: ContestantAnswerScore = {
         ContestantId: response.id,
-        ContestantName: response.name,
+        Correct: true,
+        Fastest: fastest,
         Score: score,
+        BonusPoints: score - 1,
       };
-      roundScores.push(contestantScore);
+      roundScores.push(contestantAnswerScore);
     });
 
     const updatedContestants = contestants.map((contestant) => {
@@ -247,18 +259,32 @@ export default function QuizHoster() {
         score:
           contestant.score +
           getContestantScoreForRound(roundScores, contestant.id),
+        bonusPoints:
+          contestant.bonusPoints +
+          getContestantBonusPointsForRound(roundScores, contestant.id),
       };
     });
     setContestants(updatedContestants);
     const updateCommands = updatedContestants.map((contestant) => {
       return {
         ContestantId: contestant.id,
-        Update: { Score: contestant.score },
+        Update: {
+          Score: contestant.score,
+          BonusPoints: contestant.bonusPoints,
+        },
       };
     });
-    axios.post(`/api/contestants/updates`, updateCommands).then(() => {
-      setShowQuizMarker(false);
-    });
+    const answersUpdateCommand = {
+      QuestionNo: currentQuestionNumber,
+      AnswerUpdates: roundScores,
+    };
+    axios
+      .post(`/api/quizzes/${id}/updatecontestantanswers`, answersUpdateCommand)
+      .then(() => {
+        axios.post(`/api/contestants/updates`, updateCommands).then(() => {
+          setShowQuizMarker(false);
+        });
+      });
     if (isFinalQuestion()) {
       updateQuizStatePendingResults();
       messageContestantsPendingResults();
@@ -326,6 +352,7 @@ export default function QuizHoster() {
           name: contestant.name,
           id: contestant.id,
           score: contestant.score,
+          bonusPoints: contestant.bonusPoints,
         } as Contestant;
       });
       setContestants(contestantsList);
@@ -513,12 +540,18 @@ export default function QuizHoster() {
                 <Typography component="h1" variant="h5">
                   Quiz Standings
                 </Typography>
-                <QuizStandings contestantStandings={contestants} />
+                <QuizStandings
+                  contestantStandings={contestants}
+                  quizState={currentQuizState}
+                />
               </>
             ) : (
               <div className={classes.finalStandings}>
                 <h1>Final Standings</h1>
-                <QuizStandings contestantStandings={contestants} />
+                <QuizStandings
+                  contestantStandings={contestants}
+                  quizState={currentQuizState}
+                />
                 <Button
                   type="submit"
                   variant="contained"

--- a/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -8,25 +8,132 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Paper from "@material-ui/core/Paper";
 import Contestant from "./Contestant";
+import QuizState from "../Common/QuizState";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   table: {
     minWidth: 100,
   },
-});
+  tableheader: {
+    backgroundColor: theme.palette.primary.main,
+    color: "#ffffff",
+  },
+  emojiCell: {
+    //maxWidth: "2em",
+    paddingLeft: 0,
+  },
+  tableheaderCell: {
+    color: "#ffffff",
+  },
+  tableheaderRankCell: {
+    color: "#ffffff",
+    //maxWidth: "2em",
+    paddingRight: 0,
+  },
+  ownRank: {
+    color: theme.palette.primary.main,
+    fontWeight: "bold",
+    //maxWidth: "2em",
+    paddingRight: 0,
+  },
+  otherRank: {
+    color: "#000000",
+    //maxWidth: "2em",
+    paddingRight: 0,
+  },
+  ownName: {
+    color: theme.palette.primary.main,
+    fontWeight: "bold",
+  },
+  otherName: {
+    color: "#000000",
+  },
+  ownScore: {
+    color: theme.palette.primary.main,
+    fontWeight: "bold",
+  },
+  otherScore: {
+    color: "#000000",
+    fontWeight: "bold",
+  },
+}));
 
 export default function QuizStandings(props: {
   contestantStandings: Contestant[];
+  quizState: QuizState;
 }) {
   const classes = useStyles();
+  const [participantId, setParticipantId] = useState<string>("");
+  const [rankings, setRankings] = useState<{ [key: string]: number }>({});
+
+  useEffect(() => {
+    setParticipantId(localStorage.getItem("participantId") || "");
+
+    const newRankings: { [key: string]: number } = {};
+    let currentRank = 0;
+    let currentScore = -999999;
+    let currentRankCount = 0;
+    props.contestantStandings
+      .sort((a, b) => b.score - a.score)
+      .forEach((contestant) => {
+        if (contestant.score == currentScore) {
+          newRankings[contestant.id] = currentRank;
+          currentRankCount += 1;
+        } else {
+          currentRank += currentRankCount + 1;
+          currentScore = contestant.score;
+          newRankings[contestant.id] = currentRank;
+          currentRankCount = 0;
+        }
+      });
+    setRankings(newRankings);
+  }, [props.contestantStandings]);
+
+  const getNameClass = (id: string) => {
+    if (id == participantId) {
+      return classes.ownName;
+    } else {
+      return classes.otherName;
+    }
+  };
+
+  const getScoreClass = (id: string) => {
+    if (id == participantId) {
+      return classes.ownScore;
+    } else {
+      return classes.otherScore;
+    }
+  };
+
+  const getRankClass = (id: string) => {
+    if (id == participantId) {
+      return classes.ownRank;
+    } else {
+      return classes.otherRank;
+    }
+  };
 
   return (
     <TableContainer component={Paper}>
-      <Table className={classes.table} aria-label="simple table">
+      <Table size="small" className={classes.table} aria-label="simple table">
         <TableHead>
-          <TableRow>
-            <TableCell>Name</TableCell>
-            <TableCell align="center">Score</TableCell>
+          <TableRow className={classes.tableheader}>
+            <TableCell size="small" className={classes.tableheaderRankCell}>
+              Rank
+            </TableCell>
+            <TableCell className={classes.emojiCell}></TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Name
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Correct
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Bonus Points
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Total Score
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -34,10 +141,44 @@ export default function QuizStandings(props: {
             .sort((a, b) => b.score - a.score)
             .map((contestantStanding) => (
               <TableRow key={contestantStanding.name}>
-                <TableCell component="th" scope="row">
+                <TableCell
+                  size="small"
+                  component="th"
+                  scope="row"
+                  className={getRankClass(contestantStanding.id)}
+                >
+                  {rankings[contestantStanding.id]}
+                </TableCell>
+                <TableCell align="center" className={classes.emojiCell}>
+                  {rankings[contestantStanding.id] == 1 &&
+                  props.quizState == QuizState.QuizEnded
+                    ? "👑"
+                    : ""}
+                </TableCell>
+                <TableCell
+                  align="center"
+                  className={getNameClass(contestantStanding.id)}
+                >
                   {contestantStanding.name}
                 </TableCell>
-                <TableCell align="center">{contestantStanding.score}</TableCell>
+                <TableCell
+                  align="center"
+                  className={getNameClass(contestantStanding.id)}
+                >
+                  {contestantStanding.score - contestantStanding.bonusPoints}
+                </TableCell>
+                <TableCell
+                  align="center"
+                  className={getNameClass(contestantStanding.id)}
+                >
+                  {contestantStanding.bonusPoints}
+                </TableCell>
+                <TableCell
+                  align="center"
+                  className={getScoreClass(contestantStanding.id)}
+                >
+                  {contestantStanding.score}
+                </TableCell>
               </TableRow>
             ))}
         </TableBody>

--- a/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
@@ -97,14 +97,6 @@ export default function QuizStandings(props: {
     }
   };
 
-  const getScoreClass = (id: string) => {
-    if (id == participantId) {
-      return classes.ownScore;
-    } else {
-      return classes.otherScore;
-    }
-  };
-
   const getRankClass = (id: string) => {
     if (id == participantId) {
       return classes.ownRank;
@@ -126,13 +118,7 @@ export default function QuizStandings(props: {
               Name
             </TableCell>
             <TableCell className={classes.tableheaderCell} align="center">
-              Correct
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Bonus Points
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Total Score
+              Score (Speed Bonus)
             </TableCell>
           </TableRow>
         </TableHead>
@@ -165,19 +151,7 @@ export default function QuizStandings(props: {
                   align="center"
                   className={getNameClass(contestantStanding.id)}
                 >
-                  {contestantStanding.score - contestantStanding.bonusPoints}
-                </TableCell>
-                <TableCell
-                  align="center"
-                  className={getNameClass(contestantStanding.id)}
-                >
-                  {contestantStanding.bonusPoints}
-                </TableCell>
-                <TableCell
-                  align="center"
-                  className={getScoreClass(contestantStanding.id)}
-                >
-                  {contestantStanding.score}
+                  {contestantStanding.score} ({contestantStanding.bonusPoints})
                 </TableCell>
               </TableRow>
             ))}

--- a/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles((theme) => ({
     color: "#ffffff",
   },
   emojiCell: {
-    //maxWidth: "2em",
     paddingLeft: 0,
   },
   tableheaderCell: {
@@ -27,18 +26,15 @@ const useStyles = makeStyles((theme) => ({
   },
   tableheaderRankCell: {
     color: "#ffffff",
-    //maxWidth: "2em",
     paddingRight: 0,
   },
   ownRank: {
     color: theme.palette.primary.main,
     fontWeight: "bold",
-    //maxWidth: "2em",
     paddingRight: 0,
   },
   otherRank: {
     color: "#000000",
-    //maxWidth: "2em",
     paddingRight: 0,
   },
   ownName: {

--- a/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizStandings.tsx
@@ -86,19 +86,11 @@ export default function QuizStandings(props: {
   }, [props.contestantStandings]);
 
   const getNameClass = (id: string) => {
-    if (id == participantId) {
-      return classes.ownName;
-    } else {
-      return classes.otherName;
-    }
+    return id == participantId ? classes.ownName : classes.otherName;
   };
 
   const getRankClass = (id: string) => {
-    if (id == participantId) {
-      return classes.ownRank;
-    } else {
-      return classes.otherRank;
-    }
+    return id == participantId ? classes.ownRank : classes.otherRank;
   };
 
   return (

--- a/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
@@ -57,19 +57,11 @@ export default function FinalSummary(props: { participantId: string }) {
   }, [props.participantId]);
 
   const getAnswerClass = (score: number) => {
-    if (score > 0) {
-      return classes.answerIsCorrect;
-    } else {
-      return classes.answerIsIncorrect;
-    }
+    return score > 0 ? classes.answerIsCorrect : classes.answerIsIncorrect;
   };
 
   const getFastestClass = (fastest: boolean) => {
-    if (fastest) {
-      return classes.answerIsFastest;
-    } else {
-      return classes.answerIsNotFastest;
-    }
+    return fastest ? classes.answerIsFastest : classes.answerIsNotFastest;
   };
 
   return (

--- a/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
@@ -14,6 +14,10 @@ const useStyles = makeStyles((theme) => ({
   table: {
     minWidth: 100,
   },
+  questionTable: {
+    minWidth: 100,
+    marginBottom: 10,
+  },
   tableheader: {
     backgroundColor: theme.palette.primary.main,
     color: "#ffffff",
@@ -26,7 +30,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: "bold",
   },
   answerIsIncorrect: {
-    color: "#000000",
+    color: "red",
     fontWeight: "bold",
   },
   answerIsFastest: {
@@ -70,42 +74,47 @@ export default function FinalSummary(props: { participantId: string }) {
 
   return (
     <TableContainer component={Paper}>
-      <Table size="small" className={classes.table} aria-label="summary table">
-        <TableHead>
-          <TableRow className={classes.tableheader}>
-            <TableCell className={classes.tableheaderCell}>Number</TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Question
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Correct Answer
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Your Answer
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Fastest Contestant
-            </TableCell>
-            <TableCell className={classes.tableheaderCell} align="center">
-              Score
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {questionSummaries
-            .sort((a, b) => a.number - b.number)
-            .map((question: QuestionSummary) => (
-              <TableRow key={question.number}>
-                <TableCell component="th" scope="row">
-                  {question.number}
+      {questionSummaries
+        .sort((a, b) => a.number - b.number)
+        .map((question: QuestionSummary) => (
+          <Table
+            size="small"
+            className={classes.questionTable}
+            aria-label={"question table " + question.number}
+            key={question.number}
+          >
+            <TableHead>
+              <TableRow className={classes.tableheader}>
+                <TableCell
+                  align="center"
+                  colSpan={2}
+                  className={classes.tableheaderCell}
+                >
+                  {"Question " + question.number + ": " + question.question}
                 </TableCell>
-                <TableCell align="center">{question.question}</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell component="th" scope="row">
+                  Correct Answer
+                </TableCell>
                 <TableCell align="center">{question.correctAnswer}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell component="th" scope="row">
+                  Your Answer
+                </TableCell>
                 <TableCell
                   align="center"
                   className={getAnswerClass(question.score)}
                 >
                   {question.contestantAnswer}
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell component="th" scope="row">
+                  Fastest Answer
                 </TableCell>
                 <TableCell
                   align="center"
@@ -113,11 +122,16 @@ export default function FinalSummary(props: { participantId: string }) {
                 >
                   {question.fastestContestantName}
                 </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell component="th" scope="row">
+                  Score
+                </TableCell>
                 <TableCell align="center">{question.score}</TableCell>
               </TableRow>
-            ))}
-        </TableBody>
-      </Table>
+            </TableBody>
+          </Table>
+        ))}
     </TableContainer>
   );
 }

--- a/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/FinalSummary.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import axios from "axios";
+import QuestionSummary from "./QuestionSummary";
+
+const useStyles = makeStyles((theme) => ({
+  table: {
+    minWidth: 100,
+  },
+  tableheader: {
+    backgroundColor: theme.palette.primary.main,
+    color: "#ffffff",
+  },
+  tableheaderCell: {
+    color: "#ffffff",
+  },
+  answerIsCorrect: {
+    color: "green",
+    fontWeight: "bold",
+  },
+  answerIsIncorrect: {
+    color: "#000000",
+    fontWeight: "bold",
+  },
+  answerIsFastest: {
+    color: "green",
+    fontWeight: "bold",
+  },
+  answerIsNotFastest: {
+    color: "#000000",
+  },
+}));
+
+export default function FinalSummary(props: { participantId: string }) {
+  const classes = useStyles();
+  const [questionSummaries, setQuestionSummaries] = useState<QuestionSummary[]>(
+    [],
+  );
+
+  useEffect(() => {
+    axios
+      .get(`/api/contestants/${props.participantId}/finalsummary`)
+      .then((res) => {
+        setQuestionSummaries(res.data);
+      });
+  }, [props.participantId]);
+
+  const getAnswerClass = (score: number) => {
+    if (score > 0) {
+      return classes.answerIsCorrect;
+    } else {
+      return classes.answerIsIncorrect;
+    }
+  };
+
+  const getFastestClass = (fastest: boolean) => {
+    if (fastest) {
+      return classes.answerIsFastest;
+    } else {
+      return classes.answerIsNotFastest;
+    }
+  };
+
+  return (
+    <TableContainer component={Paper}>
+      <Table size="small" className={classes.table} aria-label="summary table">
+        <TableHead>
+          <TableRow className={classes.tableheader}>
+            <TableCell className={classes.tableheaderCell}>Number</TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Question
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Correct Answer
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Your Answer
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Fastest Contestant
+            </TableCell>
+            <TableCell className={classes.tableheaderCell} align="center">
+              Score
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {questionSummaries
+            .sort((a, b) => a.number - b.number)
+            .map((question: QuestionSummary) => (
+              <TableRow key={question.number}>
+                <TableCell component="th" scope="row">
+                  {question.number}
+                </TableCell>
+                <TableCell align="center">{question.question}</TableCell>
+                <TableCell align="center">{question.correctAnswer}</TableCell>
+                <TableCell
+                  align="center"
+                  className={getAnswerClass(question.score)}
+                >
+                  {question.contestantAnswer}
+                </TableCell>
+                <TableCell
+                  align="center"
+                  className={getFastestClass(question.contestantIsFastest)}
+                >
+                  {question.fastestContestantName}
+                </TableCell>
+                <TableCell align="center">{question.score}</TableCell>
+              </TableRow>
+            ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -24,6 +24,7 @@ import ParticipantMessage from "../Common/ParticipantMessage";
 import Contestant from "../QuizHosting/Contestant";
 import QuizStandings from "../QuizHosting/QuizStandings";
 import QuizState from "../Common/QuizState";
+import FinalSummary from "./FinalSummary";
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -171,6 +172,7 @@ export default function QuestionResponder() {
                 id: contestant.id,
                 name: contestant.name,
                 score: contestant.score,
+                bonusPoints: contestant.bonusPoints,
               };
             },
           );
@@ -261,8 +263,9 @@ export default function QuestionResponder() {
   return (
     <>
       <Typography component="h2" variant="h5">
-        {quizState == QuizState.FirstQuestionReady ||
-        quizState == QuizState.NextQuestionReady
+        {(quizState == QuizState.FirstQuestionReady ||
+          quizState == QuizState.NextQuestionReady) &&
+        !kicked
           ? "You're all set..."
           : quizState != QuizState.QuizEnded
           ? quizName
@@ -292,7 +295,12 @@ export default function QuestionResponder() {
           <div className={classes.finalStandings}>
             <h2>{quizName}</h2>
             <h1>Final Standings</h1>
-            <QuizStandings contestantStandings={contestantStandings} />
+            <QuizStandings
+              contestantStandings={contestantStandings}
+              quizState={quizState}
+            />
+            <h2>Questions</h2>
+            <FinalSummary participantId={participantId} />
           </div>
         </>
       ) : quizState === QuizState.FirstQuestionReady ||
@@ -324,6 +332,7 @@ export default function QuestionResponder() {
               onChange={onAnswerChange}
               value={answer}
               onKeyPress={handleEnter}
+              autoComplete="off"
             />
             <Button
               variant="contained"

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionSummary.ts
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionSummary.ts
@@ -1,0 +1,11 @@
+interface QuestionSummary {
+  number: number;
+  question: string;
+  correctAnswer: boolean;
+  contestantAnswer: string;
+  fastestContestantName: string;
+  contestantIsFastest: boolean;
+  score: number;
+}
+
+export default QuestionSummary;

--- a/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
@@ -82,10 +82,15 @@ export default function QuizJoiner() {
 
     // The user has been, or is a participant, let's check if they're a participant of this quiz.
     if (participantID) {
-      axios.get(`/api/quizzes/${id}/details/${participantID}`).then(() => {
-        setQuizForParticipantAlreadyInProgress(true);
-        setName(participantName);
-      });
+      axios
+        .get(`/api/quizzes/${id}/details/${participantID}`)
+        .then(() => {
+          setQuizForParticipantAlreadyInProgress(true);
+          setName(participantName);
+        })
+        .catch(() => {
+          setQuizForParticipantAlreadyInProgress(false);
+        });
     }
 
     async function loadQuiz() {


### PR DESCRIPTION
Added more information to Final Standings table. 


Also added a Questions summary table below Final Standings so participants can see the answers they gave and how it compared to real answer.  

API changes involve 

- New API to update ContestantAnswer after quiz master marks answers
- New API to retrieve final summary information which only returns info if quiz has state QuizEnded

Resolves #138 

See screenshot 
![image](https://user-images.githubusercontent.com/29126973/104450283-c6489400-5597-11eb-97a0-f7343f14e385.png)
