### PR TITLE
feat(webapp): Participant name must be unique in quiz

### DIFF
--- a/QuizMaster.Application/Contestants/Create.cs
+++ b/QuizMaster.Application/Contestants/Create.cs
@@ -40,8 +40,7 @@ namespace QuizMaster.Application.Contestants
 
                 var contestantName = request.ContestantName.Trim();
 
-                var existingContestant = quiz.Contestants.Find(x => x.Name == contestantName);
-                if (existingContestant == null)
+                if (quiz.Contestants.Any(x => x.Name == contestantName))
                 {
                     var contestant = new Contestant(contestantName, quiz.Id);
 

--- a/QuizMaster.Application/Contestants/Create.cs
+++ b/QuizMaster.Application/Contestants/Create.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediatR;
 using QuizMaster.Domain;
 using QuizMaster.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace QuizMaster.Application.Contestants
 {
@@ -30,25 +31,35 @@ namespace QuizMaster.Application.Contestants
 
             public async Task<Contestant> Handle(Command request, CancellationToken cancellationToken)
             {
-                var quiz = context.Quiz.SingleOrDefault(x => x.Code == request.QuizCode);
+                var quiz = context.Quiz.Include(x => x.Contestants).SingleOrDefault(x => x.Code == request.QuizCode);
 
                 if (quiz == null)
                 {
                     return null;
                 }
 
-                var contestant = new Contestant(request.ContestantName, quiz.Id);
+                var contestantName = request.ContestantName.Trim();
 
-                context.Contestants.Add(contestant);
-
-                var success = await context.SaveChangesAsync() > 0;
-
-                if (success)
+                var existingContestant = quiz.Contestants.Find(x => x.Name == contestantName);
+                if (existingContestant == null)
                 {
-                    return contestant;
-                }
+                    var contestant = new Contestant(contestantName, quiz.Id);
 
-                throw new Exception("There was a problem saving changes.");
+                    context.Contestants.Add(contestant);
+
+                    var success = await context.SaveChangesAsync() > 0;
+
+                    if (success)
+                    {
+                        return contestant;
+                    }
+
+                    throw new Exception("There was a problem saving changes.");
+                }
+                else 
+                {
+                    return null;
+                }
             }
         }
     }

--- a/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
@@ -151,6 +151,7 @@ export default function QuizJoiner() {
           <TextField
             variant="outlined"
             margin="normal"
+            error={participantNameExists}
             required
             fullWidth
             id="your-name"

--- a/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuizJoiner.tsx
@@ -37,6 +37,10 @@ export default function QuizJoiner() {
   const [quizName, setQuizName] = useState<string>("");
   const [name, setName] = useState<string>("");
   const [quizNotFound, setQuizNotFound] = useState<boolean>(false);
+  const [joinButtonDisabled, setJoinButtonDisabled] = useState<boolean>(false);
+  const [participantNameExists, setParticipantNameExists] = useState<boolean>(
+    false,
+  );
   const [
     quizForParticipantAlreadyInProgress,
     setQuizForParticipantAlreadyInProgress,
@@ -53,8 +57,9 @@ export default function QuizJoiner() {
     history.push(`/quiz/${id}`);
   };
 
-  const onHostQuizSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const onJoinQuizSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setJoinButtonDisabled(true);
     axios.get(`/api/quizzes/${id}/state`).then((res) => {
       if (res.data.quizState === QuizState.QuizNotStarted) {
         setQuizAlreadyStartedWithoutParticipant(false);
@@ -68,6 +73,10 @@ export default function QuizJoiner() {
             localStorage.setItem("participantId", res.data.id);
             localStorage.setItem("participantName", name);
             history.push(`/quiz/${id}`);
+          })
+          .catch(() => {
+            setParticipantNameExists(true);
+            setJoinButtonDisabled(false);
           });
       } else {
         setQuizAlreadyStartedWithoutParticipant(true);
@@ -114,12 +123,23 @@ export default function QuizJoiner() {
         </Typography>
       ) : quizForParticipantAlreadyInProgress ? (
         <Typography component="h2" variant="h5">
-          Hi {name}, you&apos;re already part of this quiz!
+          &apos;{quizName}&apos;
         </Typography>
       ) : (
         <Typography component="h2" variant="h5">
           Joining &apos;{quizName}&apos;...
         </Typography>
+      )}
+      {quizForParticipantAlreadyInProgress ? (
+        <Typography component="h5" variant="h6" color="primary">
+          Hi {name}, you&apos;re already part of this quiz!
+        </Typography>
+      ) : participantNameExists ? (
+        <Typography component="h5" variant="h6" color="primary">
+          Hi, that name is already taken for this quiz, please try another one!
+        </Typography>
+      ) : (
+        <></>
       )}
       {quizNotFound ? null : quizAlreadyStartedWithoutParticipant ? (
         <Typography className={classes.sorryText} color="primary">
@@ -127,7 +147,7 @@ export default function QuizJoiner() {
           you would like to join.
         </Typography>
       ) : (
-        <form className={classes.form} onSubmit={onHostQuizSubmit}>
+        <form className={classes.form} onSubmit={onJoinQuizSubmit}>
           <TextField
             variant="outlined"
             margin="normal"
@@ -160,6 +180,7 @@ export default function QuizJoiner() {
               variant="contained"
               color="primary"
               className={classes.submit}
+              disabled={joinButtonDisabled}
             >
               Let&apos;s go!
             </Button>


### PR DESCRIPTION
This PR makes the following changes

- Fixes an issue whereby a participant could join twice due to button not being disable,   now the button is disabled BEFORE the api call
- Adds a feature to check the uniqueness of a participant name so that no 2 participants in the same quiz can have the same name
- Changed formatting of display messages for cases when quiz has already started