### PR TITLE
feat(webapp): remove autoFocus on TextField in quiz responder

### DIFF
--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -332,7 +332,6 @@ export default function QuestionResponder() {
           />
           <Paper elevation={1} className={classes.answer}>
             <TextField
-              autoFocus
               required
               id="standard-required"
               label="Answer"


### PR DESCRIPTION
Closes #161 - input field no longer auto-focuses.