### PR TITLE
SEO improvements

### DIFF
--- a/quizmaster-client-app/public/index.html
+++ b/quizmaster-client-app/public/index.html
@@ -54,7 +54,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Quiz.Coffee</title>
+    <title>Quiz.Coffee - join or create a quiz</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/quizmaster-client-app/src/components/HomePage/HomePage.tsx
+++ b/quizmaster-client-app/src/components/HomePage/HomePage.tsx
@@ -131,7 +131,7 @@ function HomePage() {
               onSubmit={onJoinQuizSubmit}
               data-testid="join-quiz"
             >
-              <Typography component="h2" variant="h5" align="center">
+              <Typography component="h1" variant="h5" align="center">
                 Join quiz
               </Typography>
               <TextField


### PR DESCRIPTION
Make "join a quiz" the title of the page - most people arriving to this page will be joining a quiz.
The title shouldn't be the domain name.