### PR TITLE
fix(webapp): added await on update DB for quiz end to fix race condition

### DIFF
--- a/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizHoster.tsx
@@ -138,8 +138,8 @@ export default function QuizHoster() {
     });
   };
 
-  const updateQuizStateFinished = () => {
-    axios.post(`/api/quizzes/${id}`, { QuizState: QuizState.QuizEnded });
+  const updateQuizStateFinished = async () => {
+    await axios.post(`/api/quizzes/${id}`, { QuizState: QuizState.QuizEnded });
   };
 
   const messageContestantsQuestionStart = () => {
@@ -198,7 +198,7 @@ export default function QuizHoster() {
     setCurrentQuizState(QuizState.QuestionInProgress);
   };
 
-  const onGoToNextQuestion = () => {
+  const onGoToNextQuestion = async () => {
     if (finalQuestionCompleted) {
       const message: QuizMasterMessage = {
         state: QuizState.QuizEnded,
@@ -208,7 +208,7 @@ export default function QuizHoster() {
         kick: false,
         standings: contestants,
       };
-      updateQuizStateFinished();
+      await updateQuizStateFinished();
       axios
         .post(`/api/quizzes/${id}/command/quizmastermessage`, message)
         .then(() => {


### PR DESCRIPTION
Fixed race condition where QuizMaster sends EndofQuiz message to participant before Quiz is updated as FInished in DB.  This was preventing Question Summary from being displayed first time for participants

Fixes #159
