### PR TITLE
feat(webapp): Added loading circle to show when Example Questions are loading

### DIFF
--- a/quizmaster-client-app/src/components/QuizHosting/QuestionCreator/QuestionCreator.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionCreator/QuestionCreator.tsx
@@ -80,6 +80,9 @@ export default function QuestionCreator(props: any) {
   const [doneInitialGet, setDoneInitialGet] = useState<boolean>(false);
   const isFirstRun = useRef(true);
   const [isInitialQuestion, setIsInitialQuestion] = useState<boolean>(true);
+  const [questionsLoadingInProgress, setQuestionsLoadingInProgress] = useState(
+    false,
+  );
 
   const setQuestion = (question: string, answer: string) => {
     dispatch({ type: "add", payload: { question: question, answer: answer } });
@@ -92,9 +95,11 @@ export default function QuestionCreator(props: any) {
   };
 
   const createTenQuestions = () => {
+    setQuestionsLoadingInProgress(true);
     Axios.get(`/api/quizzes/${props.quizId}/generatequestions`).then(
       (results) => {
         dispatch({ type: "set", payload: results.data });
+        setQuestionsLoadingInProgress(false);
         setDoneInitialGet(true);
         setIsInitialQuestion(false);
       },
@@ -135,6 +140,7 @@ export default function QuestionCreator(props: any) {
         onQuestionSubmitted={setQuestion}
         onCreateTenQuestions={createTenQuestions}
         isInitialQuestion={isInitialQuestion}
+        questionsLoadingInProgress={questionsLoadingInProgress}
       />
       <Box pt={3} pb={3}>
         {dataState.data.length || !doneInitialGet ? (

--- a/quizmaster-client-app/src/components/QuizHosting/QuestionCreator/QuestionInitialiser.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuestionCreator/QuestionInitialiser.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, ChangeEvent } from "react";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import {
   Typography,
   TextField,
@@ -11,6 +12,10 @@ const useStyles = makeStyles({
   button: {
     marginTop: "10px",
   },
+  loadingCircle: {
+    textAlign: "center",
+    marginTop: "10px",
+  },
 });
 
 export default function QuestionInitialiser(props: any) {
@@ -19,6 +24,9 @@ export default function QuestionInitialiser(props: any) {
   const [isInitialQuestion, setIsInitialQuestion] = useState<boolean>(true);
   const [isInvalidQuestion, setIsInvalidQuestion] = useState(false);
   const [isInvalidAnswer, setIsInvalidAnswer] = useState(false);
+  const [questionsLoadingInProgress, setQuestionsLoadingInProgress] = useState(
+    false,
+  );
 
   const classes = useStyles();
 
@@ -57,6 +65,10 @@ export default function QuestionInitialiser(props: any) {
   useEffect(() => {
     setIsInitialQuestion(props.isInitialQuestion);
   }, []);
+
+  useEffect(() => {
+    setQuestionsLoadingInProgress(props.questionsLoadingInProgress);
+  }, [props.questionsLoadingInProgress]);
 
   useEffect(() => {
     if (inputRef.current) {
@@ -116,6 +128,13 @@ export default function QuestionInitialiser(props: any) {
           OK
         </Button>
       </form>
+      {questionsLoadingInProgress ? (
+        <div className={classes.loadingCircle}>
+          <CircularProgress />
+        </div>
+      ) : (
+        <></>
+      )}
       {isInitialQuestion ? (
         <form onSubmit={onCreateTenQuestions} data-testid="create-question">
           <Box marginTop={4}>


### PR DESCRIPTION
Now when you click the "Create 10 questions to get me started" button , a circular loading indicator appears until the request has finished and the questions are loaded.
So that the user knows after clicking the button that something is happening
Resolves #182 