### PR TITLE
Feature/add quiz options

### DIFF
--- a/QuizMaster.Application/QuizMasterMessage.cs
+++ b/QuizMaster.Application/QuizMasterMessage.cs
@@ -11,5 +11,6 @@ namespace QuizMaster.Application
         public int QuestionNumber { get; set; }
         public bool Kick { get; set; }
         public List<ContestantScore> Standings { get; set; }
+        public int QuestionTimeInSeconds { get; set; }
     }
 }

--- a/QuizMaster.Application/Quizzes/Details.cs
+++ b/QuizMaster.Application/Quizzes/Details.cs
@@ -55,6 +55,7 @@ namespace QuizMaster.Application.Quizzes
             public long TimeRemainingMs { get; set; }
             public float TimeRemainingPerc { get; set; }
             public List<Contestant> ContestantScores { get; set; }
+            public int QuestionTimeInSeconds { get; set; }
         }
 
         public class QuizMasterQuizDetails
@@ -67,6 +68,7 @@ namespace QuizMaster.Application.Quizzes
             public long? CurrentQuestionStartTime { get; set; }
             public string CurrentQuestion { get; set; }
             public List<ContestantAnswer> CurrentContestantAnswers { get; set; }
+            public int QuestionTimeInSeconds { get; set; }
         }
 
         public class QuizStateValues
@@ -147,6 +149,7 @@ namespace QuizMaster.Application.Quizzes
                         TimeRemainingMs = timeRemainingMs,
                         TimeRemainingPerc = timeRemainingPerc,
                         ContestantScores = allContestants,
+                        QuestionTimeInSeconds = quiz.QuestionTimeInSeconds,
                     };
                 }
             }
@@ -191,6 +194,7 @@ namespace QuizMaster.Application.Quizzes
                         CurrentQuestionStartTime = quiz.QuestionStartTime,
                         CurrentQuestion = questionText,
                         CurrentContestantAnswers = contestantAnswers,
+                        QuestionTimeInSeconds = quiz.QuestionTimeInSeconds,
                     };
                 }
             }

--- a/QuizMaster.Application/Quizzes/FinalSummary.cs
+++ b/QuizMaster.Application/Quizzes/FinalSummary.cs
@@ -59,14 +59,28 @@ namespace QuizMaster.Application.Quizzes
                 {
                     var answers = quiz.Contestants.Select(x =>
                     {
-                        var contestantAnswer = question.ContestantAnswers.Single(c => c.ContestantId == x.Id);
-                        return new ContestantResponse
+                        var contestantAnswer = question.ContestantAnswers.SingleOrDefault(c => c.ContestantId == x.Id);
+                        if (contestantAnswer == null)
                         {
-                            Name = x.Name,
-                            Answer = contestantAnswer.Answer,
-                            AnsweredCorrectly = contestantAnswer.Correct,
-                            AnsweredCorrectlyFastest = contestantAnswer.Fastest,
-                        };
+                            return new ContestantResponse
+                            {
+                                Name = x.Name,
+                                Answer = "",
+                                AnsweredCorrectly = false,
+                                AnsweredCorrectlyFastest = false,
+                            };
+                        }
+                        else
+                        {
+                            return new ContestantResponse
+                            {
+                                Name = x.Name,
+                                Answer = contestantAnswer.Answer,
+                                AnsweredCorrectly = contestantAnswer.Correct,
+                                AnsweredCorrectlyFastest = contestantAnswer.Fastest,
+                            };
+                        }
+
                     });
                     questionSummaries.Add(
                         new QuestionSummary

--- a/QuizMaster.Application/Quizzes/Update.cs
+++ b/QuizMaster.Application/Quizzes/Update.cs
@@ -27,6 +27,7 @@ namespace QuizMaster.Application.Quizzes
             public QuizState? QuizState { get; set; }
             public int? QuestionNo { get; set; }
             public long? QuestionStartTime { get; set; }
+            public int? QuestionTimeInSeconds { get; set; }
         }
 
         public class Handler : IRequestHandler<Command, Quiz>
@@ -50,7 +51,10 @@ namespace QuizMaster.Application.Quizzes
                 }
                 if(request.CommandBody.QuestionStartTime.HasValue){
                     quiz.QuestionStartTime = request.CommandBody.QuestionStartTime.Value;
-                }                 
+                }
+                if(request.CommandBody.QuestionTimeInSeconds.HasValue){
+                    quiz.QuestionTimeInSeconds = request.CommandBody.QuestionTimeInSeconds.Value;
+                }                                  
                 if (context.ChangeTracker.HasChanges())
                 {
                     var success = await context.SaveChangesAsync() > 0;

--- a/QuizMaster.Domain/Quiz.cs
+++ b/QuizMaster.Domain/Quiz.cs
@@ -15,6 +15,7 @@ namespace QuizMaster.Domain
             this.State = QuizState.QuizNotStarted;
             this.QuestionNo = 0;
             this.QuestionStartTime = 0;
+            this.QuestionTimeInSeconds = 30;
         }
 
         public Quiz(Guid id, String name, String code)
@@ -32,6 +33,7 @@ namespace QuizMaster.Domain
         public long QuestionStartTime { get; set; }
         public List<Contestant> Contestants { get; set; }
         public List<QuizQuestion> QuizQuestions { get; set; }
+        public int QuestionTimeInSeconds { get; set; }
 
         static string GenerateCode()
         {

--- a/QuizMaster.Persistence/Migrations/20210519233221_QuestionTimeInSeconds.Designer.cs
+++ b/QuizMaster.Persistence/Migrations/20210519233221_QuestionTimeInSeconds.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizMaster.Persistence;
 
 namespace QuizMaster.Persistence.Migrations
 {
     [DbContext(typeof(QuizContext))]
-    partial class QuizContextModelSnapshot : ModelSnapshot
+    [Migration("20210519233221_QuestionTimeInSeconds")]
+    partial class QuestionTimeInSeconds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizMaster.Persistence/Migrations/20210519233221_QuestionTimeInSeconds.cs
+++ b/QuizMaster.Persistence/Migrations/20210519233221_QuestionTimeInSeconds.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace QuizMaster.Persistence.Migrations
+{
+    public partial class QuestionTimeInSeconds : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "QuestionTimeInSeconds",
+                table: "Quiz",
+                nullable: false,
+                defaultValue: 30);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "QuestionTimeInSeconds",
+                table: "Quiz");
+        }
+    }
+}

--- a/quizmaster-client-app/src/components/Common/QuizMasterMessage.ts
+++ b/quizmaster-client-app/src/components/Common/QuizMasterMessage.ts
@@ -8,6 +8,7 @@ interface QuizMasterMessage {
   questionNumber: number;
   kick: boolean;
   standings: Contestant[];
+  questionTimeInSeconds: number;
 }
 
 export default QuizMasterMessage;

--- a/quizmaster-client-app/src/components/QuizHosting/QuizCreating/QuizOptions.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizCreating/QuizOptions.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from "react";
+import {
+  makeStyles,
+  Paper,
+  TableContainer,
+  TextField,
+} from "@material-ui/core";
+import MaterialTable from "material-table";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+
+const useStyles = makeStyles((theme) => ({
+  tableheader: {
+    backgroundColor: theme.palette.primary.main,
+    color: "#ffffff",
+  },
+  tableheaderCell: {
+    color: "#ffffff",
+  },
+  optionValue: {
+    width: "100%",
+  },
+}));
+
+export default function QuizOptions(props: {
+  questionTimeInSeconds: number;
+  onUpdateQuestionTime: (seconds: number) => void;
+}) {
+  const classes = useStyles();
+  const { id } = useParams<{ id: string }>();
+  const [editFieldError, setEditFieldError] = useState({
+    error: false,
+    label: "",
+    helperText: "",
+    validateInput: false,
+  });
+  const timeInSecondsOptionName = "Number of seconds to answer each question";
+  const [optionsTableData, setOptionsTableData] = useState([
+    {
+      optionName: timeInSecondsOptionName,
+      optionValue: props.questionTimeInSeconds,
+    },
+  ]);
+
+  const tableColumns = [
+    {
+      title: "",
+      field: "optionName",
+      editable: "never",
+    },
+    {
+      title: "",
+      field: "optionValue",
+      // eslint-disable-next-line react/display-name
+      editComponent: (props: any) => (
+        <TextField
+          className={classes.optionValue}
+          type="number"
+          value={props.value ? props.value : ""}
+          onChange={(e) => props.onChange(e.target.value)}
+          error={editFieldError.validateInput ? editFieldError.error : false}
+          label={editFieldError.validateInput ? editFieldError.helperText : ""}
+        />
+      ),
+    },
+  ];
+
+  const [columnsState, setColumnsState] = useState<any>(tableColumns);
+  useEffect(() => {
+    setColumnsState(tableColumns);
+  }, [editFieldError]);
+
+  const updateOptionValueState = (optionName: string, newOptionValue: any) => {
+    const newData = optionsTableData.map((x: any) => {
+      if (x.optionName === optionName) {
+        return { optionName: x.optionName, optionValue: newOptionValue };
+      } else {
+        return { optionName: x.optionName, optionValue: x.optionValue };
+      }
+    });
+    setOptionsTableData(newData);
+    if (optionName === timeInSecondsOptionName) {
+      axios.post(`/api/quizzes/${id}`, {
+        QuestionTimeInSeconds: parseInt(newOptionValue),
+      });
+      props.onUpdateQuestionTime(parseInt(newOptionValue));
+    }
+  };
+
+  return (
+    <TableContainer component={Paper}>
+      <div style={{ maxWidth: "100%" }}>
+        <MaterialTable
+          options={{
+            actionsColumnIndex: -1,
+            draggable: false,
+            filtering: false,
+            paging: false,
+            search: false,
+            toolbar: false,
+            sorting: false,
+          }}
+          localization={{
+            header: {
+              actions: "",
+            },
+          }}
+          columns={columnsState}
+          data={optionsTableData}
+          title="Quiz Options"
+          editable={{
+            onRowUpdate: (newData: any, oldData: any) =>
+              new Promise<void>((resolve, reject) => {
+                setTimeout(() => {
+                  const secondsStr = String(newData.optionValue);
+                  if (secondsStr === "") {
+                    setColumnsState([]);
+                    setEditFieldError({
+                      error: true,
+                      label: "required",
+                      helperText: "Required",
+                      validateInput: true,
+                    });
+                    reject();
+                    return;
+                  } else if (
+                    !secondsStr.match(/\d+/) ||
+                    parseInt(secondsStr) < 5 ||
+                    parseInt(secondsStr) > 300
+                  ) {
+                    setEditFieldError({
+                      error: true,
+                      label: "mustbeint",
+                      helperText: "Must be a whole number between 5 and 300",
+                      validateInput: true,
+                    });
+                    reject();
+                    return;
+                  } else {
+                    resolve();
+                    if (oldData) {
+                      updateOptionValueState(
+                        newData.optionName,
+                        newData.optionValue,
+                      );
+                    }
+                  }
+                }, 600);
+              }),
+          }}
+        />
+      </div>
+    </TableContainer>
+  );
+}

--- a/quizmaster-client-app/src/components/QuizHosting/QuizCreating/QuizWizard.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizCreating/QuizWizard.tsx
@@ -17,6 +17,7 @@ import { Alert } from "@material-ui/lab";
 import QuizState from "../../Common/QuizState";
 import ResetQuizModal from "./ResetQuizModal";
 import StartQuizModal from "./StartQuizModal";
+import QuizOptions from "./QuizOptions";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,11 +74,15 @@ export default function QuizWizard() {
   const [resetSuccessOpen, setResetSuccessOpen] = useState<boolean>(false);
   const [startQuizAlertOpen, setStartQuizAlertOpen] = useState<boolean>(false);
   const [contestantsArrived, setContestantsArrived] = useState<boolean>(false);
+  const [questionTimeInSeconds, setQuestionTimeInSeconds] = useState<number>(
+    10,
+  );
 
   useEffect(() => {
     axios.get(`/api/quizzes/${id}`).then((res) => {
       setQuizCode(res.data.code);
       setQuizName(res.data.name);
+      setQuestionTimeInSeconds(res.data.questionTimeInSeconds);
     });
   }, [id]);
 
@@ -96,6 +101,10 @@ export default function QuizWizard() {
     }
   };
 
+  const onUpdateQuestionTime = (seconds: number) => {
+    setQuestionTimeInSeconds(seconds);
+  };
+
   const getStepContent = () => {
     return activeStep === 0 ? (
       <div className={classes.stepContainer}>
@@ -105,7 +114,12 @@ export default function QuizWizard() {
         />
       </div>
     ) : activeStep === 1 ? (
-      <div className={classes.stepContainer}>No options yet.</div>
+      <div className={classes.stepContainer}>
+        <QuizOptions
+          questionTimeInSeconds={questionTimeInSeconds}
+          onUpdateQuestionTime={onUpdateQuestionTime}
+        />
+      </div>
     ) : (
       <div className={classes.stepContainer}>
         <HostLobby

--- a/quizmaster-client-app/src/components/QuizHosting/QuizPlaying/QuizHoster.tsx
+++ b/quizmaster-client-app/src/components/QuizHosting/QuizPlaying/QuizHoster.tsx
@@ -51,7 +51,6 @@ export default function QuizHoster() {
   const [showQuizMarker, setShowQuizMarker] = useState<boolean>(true);
   const [answers, setAnswers] = useState<Data[]>([]);
   const [quizQuestions, setQuizQuestions] = useState<QuizQuestion[]>([]);
-  const settingsTotalTimeInSeconds = 90;
   const [totalTimeInSeconds, setTotalTimeInSeconds] = useState<number>(0);
   const [questionStartTime, setQuestionStartTime] = useState<number>(0);
   const [currentQuestionNumber, setCurrentQuestionNumber] = useState<number>(1);
@@ -88,7 +87,7 @@ export default function QuizHoster() {
 
   const roundIsComplete = () =>
     (timeLeftAsAPercentage === 0 || answers.length === contestants.length) &&
-    answers.length > 0;
+    contestants.length > 0;
 
   function getContestantScoreForRound(
     scores: ContestantAnswerScore[],
@@ -152,10 +151,10 @@ export default function QuizHoster() {
       questionNumber: quizQuestion?.QuestionNumber ?? 1,
       kick: false,
       standings: [],
+      questionTimeInSeconds: totalTimeInSeconds,
     };
 
     axios.post(`/api/quizzes/${id}/command/quizmastermessage`, message);
-    setTotalTimeInSeconds(settingsTotalTimeInSeconds);
     setQuestionStartTime(Date.now());
     setTimeLeftAsAPercentage(100);
   };
@@ -168,6 +167,7 @@ export default function QuizHoster() {
       questionNumber: currentQuestionNumber + 1,
       kick: false,
       standings: [],
+      questionTimeInSeconds: totalTimeInSeconds,
     };
 
     axios.post(`/api/quizzes/${id}/command/quizmastermessage`, message);
@@ -181,6 +181,7 @@ export default function QuizHoster() {
       questionNumber: 0,
       kick: false,
       standings: [],
+      questionTimeInSeconds: totalTimeInSeconds,
     };
 
     axios.post(`/api/quizzes/${id}/command/quizmastermessage`, message);
@@ -208,6 +209,7 @@ export default function QuizHoster() {
         questionNumber: 0,
         kick: false,
         standings: contestants,
+        questionTimeInSeconds: totalTimeInSeconds,
       };
       await updateQuizStateFinished();
       axios
@@ -357,7 +359,7 @@ export default function QuizHoster() {
     let contestantsList: Contestant[] = [];
     axios.get(`/api/quizzes/${id}/details`).then((res) => {
       setQuizName(res.data.quizName);
-      setTotalTimeInSeconds(settingsTotalTimeInSeconds);
+      setTotalTimeInSeconds(res.data.questionTimeInSeconds);
 
       contestantsList = res.data.contestants.map((contestant: any) => {
         return {
@@ -408,6 +410,7 @@ export default function QuizHoster() {
           questionNumber: 1,
           kick: false,
           standings: [],
+          questionTimeInSeconds: totalTimeInSeconds,
         };
         axios.post(`/api/quizzes/${id}/command/quizmastermessage`, message);
       } else if (res.data.quizState === QuizState.QuestionInProgress) {

--- a/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
+++ b/quizmaster-client-app/src/components/QuizParticipating/QuestionResponder.tsx
@@ -66,7 +66,6 @@ export default function QuestionResponder() {
   const { id } = useParams<{ id: string }>();
   const [participantId, setParticipantId] = useState<string>("");
   const [startTime, setStartTime] = useState<number>(0);
-  const settingsTotalTimeInSeconds = 90;
   const [totalTimeInSeconds, setTotalTimeInSeconds] = useState<number>(0);
   const [answerSubmitted, setAnswerSubmitted] = useState<boolean>(false);
   const [kicked, setKicked] = useState<boolean>(false);
@@ -157,11 +156,11 @@ export default function QuestionResponder() {
         setPageLoading(false);
         setQuizName(res.data.quizName);
         setQuestionNo(res.data.questionNo);
+        setTotalTimeInSeconds(res.data.questionTimeInSeconds);
         if (res.data.quizState === QuizState.QuestionInProgress) {
           setQuizQuestion(
             new QuizQuestion(res.data.question, "", res.data.questionNo),
           );
-          setTotalTimeInSeconds(settingsTotalTimeInSeconds);
           setStartTime(res.data.questionStartTime);
           if (res.data.answer !== "") {
             setAnswerSubmitted(true);
@@ -233,7 +232,7 @@ export default function QuestionResponder() {
               ),
             );
             setQuestionNo(message.questionNumber);
-            setTotalTimeInSeconds(settingsTotalTimeInSeconds);
+            setTotalTimeInSeconds(message.questionTimeInSeconds);
             setStartTime(Date.now());
             setAnswerSubmitted(false);
             setTimeLeftAsAPercentage(100);


### PR DESCRIPTION
Quiz Master can now edit the number of seconds a contestant has for answering a question by using the Options tab.  
This parameter is used for all questions in the quiz.  

Fixed an issue whereby Quiz Master couldn't continue to next question if no contestants submitted an answer

Fixed an issue whereby api application would throw an error during Final Summary if a contestant hadnt's submitted an answer to a question

Resolves #89 